### PR TITLE
Tweaks to make actions more reusable.

### DIFF
--- a/src/common/ProgressDialog.tsx
+++ b/src/common/ProgressDialog.tsx
@@ -6,19 +6,25 @@ import {
   ModalOverlay,
 } from "@chakra-ui/modal";
 import { Progress } from "@chakra-ui/progress";
+import { ReactNode } from "react";
 
 const doNothing = () => {};
 
-interface FlashProgressProps {
+export interface ProgressDialogParameters {
+  header: ReactNode;
   progress: number | undefined;
 }
 
-const FlashProgress = ({ progress }: FlashProgressProps) => {
+interface ProgressDialogProps extends ProgressDialogParameters {
+  isOpen: boolean;
+}
+
+const ProgressDialog = ({ header, progress }: ProgressDialogProps) => {
   return (
     <Modal isOpen={progress !== undefined} onClose={doNothing} isCentered>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>Flashing code</ModalHeader>
+        <ModalHeader>{header}</ModalHeader>
         <ModalBody>
           <Progress value={progress! * 100} mb={3} />
         </ModalBody>
@@ -27,4 +33,4 @@ const FlashProgress = ({ progress }: FlashProgressProps) => {
   );
 };
 
-export default FlashProgress;
+export default ProgressDialog;

--- a/src/common/use-dialogs.tsx
+++ b/src/common/use-dialogs.tsx
@@ -9,6 +9,7 @@ import {
   InputDialogParameters,
   InputDialogParametersWithActions,
 } from "./InputDialog";
+import ProgressDialog, { ProgressDialogParameters } from "./ProgressDialog";
 
 const DialogContext = React.createContext<Dialogs | undefined>(undefined);
 
@@ -23,16 +24,27 @@ export const DialogProvider = ({ children }: DialogProviderProps) => {
   const [inputDialogState, setInputDialogState] = useState<
     InputDialogParametersWithActions | undefined
   >(undefined);
+  const [progressDialogState, setProgressDialogState] = useState<
+    ProgressDialogParameters | undefined
+  >(undefined);
 
   const dialogs = useMemo(
-    () => new Dialogs(setConfirmDialogState, setInputDialogState),
-    [setConfirmDialogState]
+    () =>
+      new Dialogs(
+        setConfirmDialogState,
+        setInputDialogState,
+        setProgressDialogState
+      ),
+    [setConfirmDialogState, setInputDialogState, setProgressDialogState]
   );
   return (
     <DialogContext.Provider value={dialogs}>
       <>
         {confirmDialogState && <ConfirmDialog isOpen {...confirmDialogState} />}
         {inputDialogState && <InputDialog isOpen {...inputDialogState} />}
+        {progressDialogState && (
+          <ProgressDialog isOpen {...progressDialogState} />
+        )}
         {children}
       </>
     </DialogContext.Provider>
@@ -46,6 +58,9 @@ export class Dialogs {
     ) => void,
     private inputDialogSetState: (
       options: InputDialogParametersWithActions | undefined
+    ) => void,
+    private progressDialogSetState: (
+      options: ProgressDialogParameters | undefined
     ) => void
   ) {}
 
@@ -75,6 +90,14 @@ export class Dialogs {
         onConfirm: (validValue: string) => resolve(validValue),
       });
     });
+  }
+
+  progress(options: ProgressDialogParameters): void {
+    if (options.progress === undefined) {
+      this.progressDialogSetState(undefined);
+    } else {
+      this.progressDialogSetState(options);
+    }
   }
 }
 

--- a/src/project/FlashButton.tsx
+++ b/src/project/FlashButton.tsx
@@ -1,10 +1,8 @@
 import { Tooltip } from "@chakra-ui/react";
-import { useCallback, useState } from "react";
 import { RiFlashlightFill } from "react-icons/ri";
 import CollapsableButton, {
   CollapsibleButtonProps,
 } from "../common/CollapsibleButton";
-import FlashProgress from "./FlashProgress";
 import { useProjectActions } from "./project-hooks";
 
 /**
@@ -14,13 +12,8 @@ const FlashButton = (
   props: Omit<CollapsibleButtonProps, "onClick" | "text" | "icon">
 ) => {
   const actions = useProjectActions();
-  const [progress, setProgress] = useState<number | undefined>();
-  const handleFlash = useCallback(() => {
-    actions.flash(setProgress);
-  }, [actions]);
   return (
     <>
-      <FlashProgress progress={progress} />
       <Tooltip
         hasArrow
         placement="top-start"
@@ -28,9 +21,8 @@ const FlashButton = (
       >
         <CollapsableButton
           {...props}
-          disabled={typeof progress !== "undefined"}
           icon={<RiFlashlightFill />}
-          onClick={handleFlash}
+          onClick={actions.flash}
           text="Flash"
         />
       </Tooltip>


### PR DESCRIPTION
- Move dialog handling for flash into project-actions so it's easy to
  trigger a flash from elsewhere in the UI
- Add an action that's currrently under debate: downloading main.py
  named as per the project name.