### PR TITLE
Run e2e tests after deploy for review only.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,14 +101,15 @@ jobs:
       - *update_version
       - *save_npm_cache
       - *build
+      # Unlike other stages deploy, first so we still get deployments when e2e fails.
+      - *queue_until_front_of_line
+      - *deploy
+      - *invalidate
       - *chrome-deps
       - *serve
       - *serve-wait
       - *e2e
       - *store_reports
-      - *queue_until_front_of_line
-      - *deploy
-      - *invalidate
 
   staging:
     <<: *defaults


### PR DESCRIPTION
Just re-sequence the steps for review branch only.

Helpful to allow early demos from work-in-progress or quick hacks where it's not worth working through e2e failures before showing someone, or even just to figure out why e2e failed without running it locally.

https://github.com/microbit-foundation/python-editor-next/issues/69