### PR TITLE
Reinstate timeouts from V2

### DIFF
--- a/src/device/async-util.test.ts
+++ b/src/device/async-util.test.ts
@@ -1,5 +1,4 @@
-import { TimeoutError } from "puppeteer";
-import { withTimeout } from "./async-util";
+import { TimeoutError, withTimeout } from "./async-util";
 
 describe("withTimeout", () => {
   it("times out", async () => {

--- a/src/device/async-util.ts
+++ b/src/device/async-util.ts
@@ -1,4 +1,4 @@
-class TimeoutError extends Error {}
+export class TimeoutError extends Error {}
 
 /**
  * Utility to time out an action after a delay.

--- a/src/device/device.ts
+++ b/src/device/device.ts
@@ -1,8 +1,7 @@
 import EventEmitter from "events";
-import { TimeoutError } from "puppeteer";
 import { Logging } from "../logging/logging";
 import { NullLogging } from "../logging/null";
-import { withTimeout } from "./async-util";
+import { withTimeout, TimeoutError } from "./async-util";
 import { BoardId } from "./board-id";
 import { DAPWrapper } from "./dap-wrapper";
 import { PartialFlashing } from "./partial-flashing";

--- a/src/device/partial-flashing.ts
+++ b/src/device/partial-flashing.ts
@@ -5,9 +5,8 @@
  * https://github.com/microsoft/pxt-microbit/blob/master/editor/flash.ts
  */
 import { DAPLink } from "dapjs";
-import { TimeoutError } from "puppeteer";
 import { Logging } from "../logging/logging";
-import { withTimeout } from "./async-util";
+import { withTimeout, TimeoutError } from "./async-util";
 import { BoardId } from "./board-id";
 import { DAPWrapper } from "./dap-wrapper";
 import { FlashDataSource } from "./device";


### PR DESCRIPTION
Done in connectInternal rather than just for flashing as they call the
same underlying code so presumably both can benefit (flashing rejigged
to call the connect call always).

The equivalent timeout in V2 is in python-main.js search for connectTimeout.

See #13.