### PR TITLE
Re-render the progress dialog less often.

### DIFF
--- a/src/common/ProgressDialog.tsx
+++ b/src/common/ProgressDialog.tsx
@@ -26,7 +26,7 @@ const ProgressDialog = ({ header, progress }: ProgressDialogProps) => {
       <ModalContent>
         <ModalHeader>{header}</ModalHeader>
         <ModalBody>
-          <Progress value={progress! * 100} mb={3} />
+          <Progress min={0} max={1} value={progress} mb={3} />
         </ModalBody>
       </ModalContent>
     </Modal>

--- a/src/project/project-actions.tsx
+++ b/src/project/project-actions.tsx
@@ -255,11 +255,19 @@ export class ProjectActions {
     }
 
     try {
+      let lastDialogUpdate: number | undefined;
       const progress = (value: number | undefined) => {
-        this.dialogs.progress({
-          header: "Flashing code",
-          progress: value,
-        });
+        if (
+          value === undefined ||
+          lastDialogUpdate === undefined ||
+          value - lastDialogUpdate > 0.01
+        ) {
+          this.dialogs.progress({
+            header: "Flashing code",
+            progress: value,
+          });
+          lastDialogUpdate = value;
+        }
       };
       await this.device.flash(this.fs, { partial: true, progress });
     } catch (e) {


### PR DESCRIPTION
We could probably make it do less work too, but it's pretty minimal in
the V2 version and it still makes a meaninful impact there.

See #13 