### PR TITLE
Set defaults in the theme.

### DIFF
--- a/src/common/ConfirmDialog.tsx
+++ b/src/common/ConfirmDialog.tsx
@@ -56,15 +56,15 @@ export const ConfirmDialog = ({
           </AlertDialogHeader>
           <AlertDialogBody>{body}</AlertDialogBody>
           <AlertDialogFooter>
-            <Button
-              colorScheme="blimpPurple"
-              variant="outline"
-              ref={leastDestructiveRef}
-              onClick={onCancel}
-            >
+            <Button ref={leastDestructiveRef} onClick={onCancel}>
               Cancel
             </Button>
-            <Button colorScheme="red" onClick={onConfirm} ml={3}>
+            <Button
+              variant="solid"
+              colorScheme="red"
+              onClick={onConfirm}
+              ml={3}
+            >
               {actionLabel}
             </Button>
           </AlertDialogFooter>

--- a/src/common/InputDialog.tsx
+++ b/src/common/InputDialog.tsx
@@ -95,16 +95,11 @@ export const InputDialog = <T extends unknown>({
             </VStack>
           </ModalBody>
           <ModalFooter>
-            <Button
-              colorScheme="blimpPurple"
-              variant="outline"
-              ref={leastDestructiveRef}
-              onClick={onCancel}
-            >
+            <Button ref={leastDestructiveRef} onClick={onCancel}>
               Cancel
             </Button>
             <Button
-              colorScheme="blimpPurple"
+              variant="solid"
               onClick={() => onConfirm(value)}
               ml={3}
               isDisabled={Boolean(error)}

--- a/src/editor/ZoomControls.tsx
+++ b/src/editor/ZoomControls.tsx
@@ -38,6 +38,7 @@ const ZoomControls = ({ size, ...props }: ZoomControlsProps) => {
         aria-label="Zoom in"
         onClick={handleZoomIn}
         colorScheme="gray"
+        variant="solid"
       />
       <IconButton
         size={size}
@@ -46,6 +47,7 @@ const ZoomControls = ({ size, ...props }: ZoomControlsProps) => {
         aria-label="Zoom out"
         onClick={handleZoomOut}
         colorScheme="gray"
+        variant="solid"
       />
     </HStack>
   );

--- a/src/files/FilesAreaNav.tsx
+++ b/src/files/FilesAreaNav.tsx
@@ -5,7 +5,7 @@ import LoadButton from "../project/LoadButton";
 const FilesAreaNav = () => {
   return (
     <ButtonGroup pl={1} pr={1} spacing={0}>
-      <NewButton variant="ghost" mode="icon" />
+      <NewButton variant="ghost" mode="icon" colorScheme="black" />
       <LoadButton variant="ghost" mode="icon" colorScheme="black" />
     </ButtonGroup>
   );

--- a/src/project/ConnectDisconnectButton.tsx
+++ b/src/project/ConnectDisconnectButton.tsx
@@ -25,8 +25,6 @@ const ConnectDisconnectButton = () => {
         size="lg"
         leftIcon={<RiUsbLine />}
         onClick={handleToggleConnected}
-        variant="outline"
-        colorScheme="blimpPurple"
       >
         {connected ? "Disconnect" : "Connect"}
       </Button>

--- a/src/project/DownloadButton.tsx
+++ b/src/project/DownloadButton.tsx
@@ -22,7 +22,7 @@ const DownloadButton = (props: DownloadButtonProps) => {
     <Tooltip hasArrow placement="top-start" label="Download a project hex file">
       <CollapsableButton
         {...props}
-        colorScheme="blimpPurple"
+        variant="solid"
         icon={<RiDownload2Line />}
         onClick={actions.download}
         text="Download"

--- a/src/project/DownloadFlashButton.tsx
+++ b/src/project/DownloadFlashButton.tsx
@@ -43,13 +43,13 @@ const DownloadFlashButton = ({ size }: DownloadFlashButtonProps) => {
               <DownloadButton width={buttonWidth} mode={"button"} size={size} />
             )}
             <MenuButton
+              variant="solid"
               borderLeft="1px"
               borderRadius="4xl"
               as={IconButton}
               // Shift to compensate for border radius on the right
               icon={<MdMoreVert style={{ marginLeft: "-0.3rem" }} />}
               size={size}
-              colorScheme="blimpPurple"
             />
             <Portal>
               {/* z-index above the xterm.js's layers */}

--- a/src/project/FlashButton.tsx
+++ b/src/project/FlashButton.tsx
@@ -21,7 +21,7 @@ const FlashButton = (
       >
         <CollapsableButton
           {...props}
-          colorScheme="blimpPurple"
+          variant="solid"
           icon={<RiFlashlightFill />}
           onClick={actions.flash}
           text="Flash"

--- a/src/project/HelpMenu.tsx
+++ b/src/project/HelpMenu.tsx
@@ -51,6 +51,7 @@ const HelpMenu = ({ size, ...props }: HelpMenuProps) => {
         size={size}
         variant="sidebar"
         icon={<RiQuestionLine />}
+        colorScheme="gray"
         isRound
       />
       <Portal>

--- a/src/project/LanguageMenu.tsx
+++ b/src/project/LanguageMenu.tsx
@@ -30,6 +30,7 @@ const LanguageMenu = ({ size, ...props }: LanguageMenuProps) => {
         size={size}
         variant="sidebar"
         icon={<RiEarthLine />}
+        colorScheme="gray"
         isRound
       />
       <Portal>

--- a/src/project/ProjectActionBar.tsx
+++ b/src/project/ProjectActionBar.tsx
@@ -13,12 +13,7 @@ const ProjectActionBar = (props: BoxProps) => {
       </HStack>
       <HStack>
         <ConnectDisconnectButton />
-        <LoadButton
-          variant="outline"
-          mode="button"
-          size={size}
-          colorScheme="blimpPurple"
-        />
+        <LoadButton mode="button" size={size} />
         <ShareButton variant="outline" size={size} />
       </HStack>
     </HStack>

--- a/src/project/ShareButton.tsx
+++ b/src/project/ShareButton.tsx
@@ -19,7 +19,6 @@ const ShareButton = (props: ButtonProps) => {
     <Tooltip hasArrow placement="top-start" label="Share your project">
       <IconButton
         icon={<RiShareLine />}
-        colorScheme="blimpPurple"
         mode="icon"
         onClick={handleShare}
         {...props}

--- a/src/settings/SettingsArea.tsx
+++ b/src/settings/SettingsArea.tsx
@@ -117,7 +117,6 @@ const SettingsArea = () => {
           id="highlight-code-structure"
           isChecked={settings.highlightCodeStructure}
           onChange={handleChangeHighlightCodeStructure}
-          colorScheme="blimpPurple"
         />
       </FormControl>
     </VStack>

--- a/src/settings/SettingsButton.tsx
+++ b/src/settings/SettingsButton.tsx
@@ -13,6 +13,7 @@ const SettingsButton = () => {
         variant="sidebar"
         icon={<RiSettings2Line />}
         isRound
+        colorScheme="gray"
         onClick={() => setOpen(true)}
       />
       <SettingsDialog isOpen={open} onClose={() => setOpen(false)} />

--- a/src/settings/SettingsDialog.tsx
+++ b/src/settings/SettingsDialog.tsx
@@ -29,7 +29,7 @@ export const SettingsDialog = ({ isOpen, onClose }: SettingsDialogProps) => {
             <SettingsArea />
           </ModalBody>
           <ModalFooter>
-            <Button colorScheme="blimpPurple" onClick={onClose}>
+            <Button variant="solid" onClick={onClose}>
               Close
             </Button>
           </ModalFooter>

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,4 +1,9 @@
-import { extendTheme, theme } from "@chakra-ui/react";
+import {
+  extendTheme,
+  theme,
+  withDefaultColorScheme,
+  withDefaultVariant,
+} from "@chakra-ui/react";
 
 export const codeFontFamily = "Source Code Pro, monospace";
 export const backgroundColorTerm = "#333333"; // Equivalent of "var(--chakra-colors-blackAlpha-800)" on white.
@@ -15,7 +20,8 @@ const overrides = {
     "4xl": "2rem",
   },
   colors: {
-    blimpPurple: {
+    brand: {
+      // As provided by Blimp.
       300: "#6f6ac1",
       400: "#6e5fc1",
       500: "#6c4bc1",
@@ -32,9 +38,9 @@ const overrides = {
       variants: {
         outline: {
           borderWidth: "2px",
-          color: "blimpPurple.500",
+          color: "brand.500",
           _hover: {
-            color: "blimpPurple.600",
+            color: "brand.600",
           },
         },
         sidebar: (props: any) => {
@@ -67,7 +73,7 @@ const overrides = {
               ...base.tab,
               borderRadius: "unset",
               _selected: {
-                color: "blimpPurple.300",
+                color: "brand.300",
                 bg: "var(--content-background)",
                 outline: "none",
               },
@@ -79,4 +85,11 @@ const overrides = {
   },
 };
 
-export default extendTheme(overrides);
+export default extendTheme(
+  overrides,
+  withDefaultColorScheme({ colorScheme: "brand" }),
+  withDefaultVariant({
+    variant: "outline",
+    components: ["Button", "IconButton"],
+  })
+);

--- a/src/workbench/LeftPanel.tsx
+++ b/src/workbench/LeftPanel.tsx
@@ -95,7 +95,7 @@ const LeftPanelContents = ({ panes, ...props }: LeftPanelContentsProps) => {
         onChange={setIndex}
         index={index}
       >
-        <TabList background="transparent linear-gradient(to bottom, var(--chakra-colors-blimpPurple-500) 0%, #7BCDC2 100%) 0% 0% no-repeat padding-box;">
+        <TabList background="transparent linear-gradient(to bottom, var(--chakra-colors-brand-500) 0%, #7BCDC2 100%) 0% 0% no-repeat padding-box;">
           <Box width="3.75rem" mt="1.375rem" ml="auto" mr="auto" mb="11.5vh">
             <LogoFace fill="white" />
           </Box>


### PR DESCRIPTION
Less manual colour styling required.

Primary CTAs need to be set to solid, outline is the default.

https://chakra-ui.com/docs/theming/customize-theme#theme-extension-withdefaultcolorscheme

Not sure how I missed this documentation the other day.