### PR TITLE
Add a dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+ARG VARIANT="14-buster"
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+RUN apt-get update && apt-get install -y vim

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+// For format details, see https://aka.ms/devcontainer.json.
+// For image args, see the README at https://github.com/microsoft/vscode-dev-containers/tree/v0.163.1/containers/javascript-node
+{
+  "name": "python-editor-next",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": { "VARIANT": "14" }
+  },
+  "extensions": ["esbenp.prettier-vscode"],
+  "portsAttributes": {
+    "3000": {
+      "label": "dev server",
+      "onAutoForward": "openBrowser"
+    }
+  },
+  "remoteUser": "node",
+  "postCreateCommand": "npm install",
+  "postStartCommand": "git config --global core.editor 'code --wait'"
+}


### PR DESCRIPTION
Uses node 14 and runs npm install.

Git config seems to be forwarded to the container but it drops the
editor settings, so configure VS Code as the editor. Seem to have to
do it when "started" for it to be late enough.

Let's see if this is a good option for Windows users.