### PR TITLE
Faff with social.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,20 +5,15 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#6c4bc1" />
-    <title>Python Editor for micro:bit</title>
-    <meta property="og:title" content="Python Editor for micro:bit" />
+    <title>Python editor for micro:bit</title>
+    <meta property="og:title" content="Python editor for micro:bit" />
     <meta
       property="og:description"
       content="Built by the Micro:bit Educational Foundation and the global Python Community."
     />
     <meta
-      property="og:image"
-      content="https://python.microbit.org/img/pyeditor.png"
-    />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta
       name="twitter:description"
-      content="A Python Editor for the BBC micro:bit, built by the Micro:bit Educational Foundation and the global Python Community."
+      content="A Python editor for the BBC micro:bit, built by the Micro:bit Educational Foundation and the global Python Community."
     />
     <% if (process.env.REACT_APP_GA_MEASUREMENT_ID &&
     (process.env.REACT_APP_STAGE === 'production' || process.env.REACT_APP_STAGE


### PR DESCRIPTION
Case consistency.

Remove image for now as it's the wrong editor so confusing when sharing
direct links.

The versioner used for production deploys will use its own social
metadata anyway.