### PR TITLE
Xterm tweaks.

### DIFF
--- a/src/serial/XTerm.tsx
+++ b/src/serial/XTerm.tsx
@@ -8,6 +8,7 @@ import { useEffect, useRef } from "react";
 import { Terminal } from "xterm";
 import { FitAddon } from "xterm-addon-fit";
 import "xterm/css/xterm.css";
+import "./xterm-custom.css";
 import {
   backgroundColorTerm,
   codeFontFamily,
@@ -30,6 +31,7 @@ const XTerm = (props: BoxProps) => {
         fontFamily: codeFontFamily,
         fontSize: defaultCodeFontSizePt * ptToPixelRatio,
         letterSpacing: 1.1,
+        screenReaderMode: true,
         theme: {
           background: backgroundColorTerm,
         },

--- a/src/serial/xterm-custom.css
+++ b/src/serial/xterm-custom.css
@@ -1,0 +1,9 @@
+.xterm-viewport::-webkit-scrollbar {
+  background-color: #333333;
+}
+.xterm-viewport::-webkit-scrollbar-thumb {
+  background: var(--chakra-colors-gray-600);
+}
+.xterm .xterm-viewport {
+  scrollbar-color: #333333 var(--chakra-colors-gray-600);
+}


### PR DESCRIPTION
- Style the scrollbar
- Enable screen reader mode. Their docs aren't really clear on the
  disadvantages of this (it's not the default). It seems to maintain
  a parallel DOM structure the same height as the visible text. That
  doesn't seem so bad and we have no way to turn it on so let's try
  it as the default.