### PR TITLE
Remove bracket matching.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@codemirror/lang-python": "~0",
     "@codemirror/language": "~0",
     "@codemirror/lint": "~0",
-    "@codemirror/matchbrackets": "~0",
     "@codemirror/state": "~0",
     "@codemirror/view": "~0",
     "@emotion/react": "^11.4.1",

--- a/src/editor/codemirror/config.ts
+++ b/src/editor/codemirror/config.ts
@@ -13,7 +13,6 @@ import { history, historyKeymap } from "@codemirror/history";
 import { python } from "@codemirror/lang-python";
 import { indentOnInput, indentUnit } from "@codemirror/language";
 import { lintKeymap } from "@codemirror/lint";
-import { bracketMatching } from "@codemirror/matchbrackets";
 import { Compartment, EditorState, Extension, Prec } from "@codemirror/state";
 import {
   drawSelection,
@@ -49,7 +48,6 @@ export const editorConfig: Extension = [
   drawSelection(),
   indentOnInput(),
   Prec.fallback(defaultHighlightStyle),
-  bracketMatching(),
   closeBrackets(),
   highlightStyle(),
   highlightActiveLine(),


### PR DESCRIPTION
No change to the package lock as we still indirectly require the package
via @codemirror/commands. But styling the brackets requires the removed
config.

Closes https://github.com/microbit-foundation/python-editor-next/issues/288