### PR TITLE
Remove the language preview markers.

### DIFF
--- a/src/settings/LanguageDialog.tsx
+++ b/src/settings/LanguageDialog.tsx
@@ -39,7 +39,7 @@ export const LanguageDialog = ({ isOpen, onClose }: LanguageDialogProps) => {
     },
     [settings, setSettings, onClose]
   );
-
+  const hasPreviewLanguages = supportedLanguages.some((l) => l.preview);
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="xl">
       <ModalOverlay>
@@ -70,10 +70,12 @@ export const LanguageDialog = ({ isOpen, onClose }: LanguageDialogProps) => {
                 <Icon as={RiExternalLinkLine} />
               </Link>
             </VStack>
-            <Text fontSize="xs" alignSelf="flex-end" mt={1}>
-              * These languages are an early preview of in-progress
-              translations.
-            </Text>{" "}
+            {hasPreviewLanguages && (
+              <Text fontSize="xs" alignSelf="flex-end" mt={1}>
+                * These languages are an early preview of in-progress
+                translations.
+              </Text>
+            )}
           </ModalBody>
           <ModalFooter>
             <Button variant="solid" onClick={onClose}>

--- a/src/settings/settings.tsx
+++ b/src/settings/settings.tsx
@@ -27,37 +27,31 @@ export const supportedLanguages: Language[] = [
     id: "zh-cn",
     name: "中文（中华人民共和国）",
     enName: "Chinese (Simplified)",
-    preview: true,
   },
   {
     id: "zh-tw",
     name: "中文（繁體，台灣）",
     enName: "Chinese (Traditional)",
-    preview: true,
   },
   {
     id: "fr",
     name: "Français",
     enName: "French",
-    preview: true,
   },
   {
     id: "ja",
     name: "日本語",
     enName: "Japanese",
-    preview: true,
   },
   {
     id: "ko",
     name: "한국어",
     enName: "Korean",
-    preview: true,
   },
   {
     id: "es-es",
     name: "Español",
     enName: "Spanish",
-    preview: true,
   },
 ];
 


### PR DESCRIPTION
Keep the mechanism as we might enable it for future beta/staging releases when testing new languages.