### PR TITLE
Add accelerometer gestures to UI strings

### DIFF
--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -847,6 +847,42 @@
     "defaultMessage": "Expand {title} module",
     "description": "Aria label for expand simulator module button"
   },
+  "simulator-gesture-3g": {
+    "defaultMessage": "3g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-6g": {
+    "defaultMessage": "6g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-8g": {
+    "defaultMessage": "8g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-down": {
+    "defaultMessage": "down",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-face-down": {
+    "defaultMessage": "face down",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-face-up": {
+    "defaultMessage": "face up",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-freefall": {
+    "defaultMessage": "freefall",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-left": {
+    "defaultMessage": "left",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-right": {
+    "defaultMessage": "right",
+    "description": "Simulator gesture option"
+  },
   "simulator-gesture-select": {
     "defaultMessage": "Select gesture",
     "description": "Aria label for the simulator gesture select input"
@@ -854,6 +890,14 @@
   "simulator-gesture-send": {
     "defaultMessage": "Send gesture",
     "description": "Aria label for the simulator gesture send button"
+  },
+  "simulator-gesture-shake": {
+    "defaultMessage": "shake",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-up": {
+    "defaultMessage": "up",
+    "description": "Simulator gesture option"
   },
   "simulator-hide": {
     "defaultMessage": "Hide simulator",

--- a/lang/ui.es-es.json
+++ b/lang/ui.es-es.json
@@ -846,6 +846,42 @@
     "defaultMessage": "Expandir módulo {title}",
     "description": "Aria label for expand simulator module button"
   },
+  "simulator-gesture-3g": {
+    "defaultMessage": "3g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-6g": {
+    "defaultMessage": "6g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-8g": {
+    "defaultMessage": "8g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-down": {
+    "defaultMessage": "down",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-face-down": {
+    "defaultMessage": "face down",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-face-up": {
+    "defaultMessage": "face up",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-freefall": {
+    "defaultMessage": "freefall",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-left": {
+    "defaultMessage": "left",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-right": {
+    "defaultMessage": "right",
+    "description": "Simulator gesture option"
+  },
   "simulator-gesture-select": {
     "defaultMessage": "Seleccionar gesto",
     "description": "Aria label for the simulator gesture select input"
@@ -853,6 +889,14 @@
   "simulator-gesture-send": {
     "defaultMessage": "Enviar gesto",
     "description": "Aria label for the simulator gesture send button"
+  },
+  "simulator-gesture-shake": {
+    "defaultMessage": "shake",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-up": {
+    "defaultMessage": "up",
+    "description": "Simulator gesture option"
   },
   "simulator-hide": {
     "defaultMessage": "Ocultar simulador",

--- a/lang/ui.fr.json
+++ b/lang/ui.fr.json
@@ -846,6 +846,42 @@
     "defaultMessage": "Développer le module {title}",
     "description": "Aria label for expand simulator module button"
   },
+  "simulator-gesture-3g": {
+    "defaultMessage": "3g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-6g": {
+    "defaultMessage": "6g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-8g": {
+    "defaultMessage": "8g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-down": {
+    "defaultMessage": "down",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-face-down": {
+    "defaultMessage": "face down",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-face-up": {
+    "defaultMessage": "face up",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-freefall": {
+    "defaultMessage": "freefall",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-left": {
+    "defaultMessage": "left",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-right": {
+    "defaultMessage": "right",
+    "description": "Simulator gesture option"
+  },
   "simulator-gesture-select": {
     "defaultMessage": "Sélectionner un geste",
     "description": "Aria label for the simulator gesture select input"
@@ -853,6 +889,14 @@
   "simulator-gesture-send": {
     "defaultMessage": "Envoyer un geste",
     "description": "Aria label for the simulator gesture send button"
+  },
+  "simulator-gesture-shake": {
+    "defaultMessage": "shake",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-up": {
+    "defaultMessage": "up",
+    "description": "Simulator gesture option"
   },
   "simulator-hide": {
     "defaultMessage": "Cacher le simulateur ",

--- a/lang/ui.ja.json
+++ b/lang/ui.ja.json
@@ -846,6 +846,42 @@
     "defaultMessage": "{title} モジュールを展開",
     "description": "Aria label for expand simulator module button"
   },
+  "simulator-gesture-3g": {
+    "defaultMessage": "3g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-6g": {
+    "defaultMessage": "6g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-8g": {
+    "defaultMessage": "8g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-down": {
+    "defaultMessage": "down",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-face-down": {
+    "defaultMessage": "face down",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-face-up": {
+    "defaultMessage": "face up",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-freefall": {
+    "defaultMessage": "freefall",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-left": {
+    "defaultMessage": "left",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-right": {
+    "defaultMessage": "right",
+    "description": "Simulator gesture option"
+  },
   "simulator-gesture-select": {
     "defaultMessage": "ジェスチャーを選択",
     "description": "Aria label for the simulator gesture select input"
@@ -853,6 +889,14 @@
   "simulator-gesture-send": {
     "defaultMessage": "ジェスチャーを送信",
     "description": "Aria label for the simulator gesture send button"
+  },
+  "simulator-gesture-shake": {
+    "defaultMessage": "shake",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-up": {
+    "defaultMessage": "up",
+    "description": "Simulator gesture option"
   },
   "simulator-hide": {
     "defaultMessage": "シミュレーターを隠す",

--- a/lang/ui.ko.json
+++ b/lang/ui.ko.json
@@ -846,6 +846,42 @@
     "defaultMessage": "{title} 모듈 펼치기",
     "description": "Aria label for expand simulator module button"
   },
+  "simulator-gesture-3g": {
+    "defaultMessage": "3g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-6g": {
+    "defaultMessage": "6g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-8g": {
+    "defaultMessage": "8g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-down": {
+    "defaultMessage": "down",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-face-down": {
+    "defaultMessage": "face down",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-face-up": {
+    "defaultMessage": "face up",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-freefall": {
+    "defaultMessage": "freefall",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-left": {
+    "defaultMessage": "left",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-right": {
+    "defaultMessage": "right",
+    "description": "Simulator gesture option"
+  },
   "simulator-gesture-select": {
     "defaultMessage": "제스처 선택",
     "description": "Aria label for the simulator gesture select input"
@@ -853,6 +889,14 @@
   "simulator-gesture-send": {
     "defaultMessage": "제스처 전송",
     "description": "Aria label for the simulator gesture send button"
+  },
+  "simulator-gesture-shake": {
+    "defaultMessage": "shake",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-up": {
+    "defaultMessage": "up",
+    "description": "Simulator gesture option"
   },
   "simulator-hide": {
     "defaultMessage": "시뮬레이터 숨기기",

--- a/lang/ui.zh-cn.json
+++ b/lang/ui.zh-cn.json
@@ -846,6 +846,42 @@
     "defaultMessage": "展开 {title} 模块",
     "description": "Aria label for expand simulator module button"
   },
+  "simulator-gesture-3g": {
+    "defaultMessage": "3g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-6g": {
+    "defaultMessage": "6g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-8g": {
+    "defaultMessage": "8g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-down": {
+    "defaultMessage": "down",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-face-down": {
+    "defaultMessage": "face down",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-face-up": {
+    "defaultMessage": "face up",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-freefall": {
+    "defaultMessage": "freefall",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-left": {
+    "defaultMessage": "left",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-right": {
+    "defaultMessage": "right",
+    "description": "Simulator gesture option"
+  },
   "simulator-gesture-select": {
     "defaultMessage": "选择手势",
     "description": "Aria label for the simulator gesture select input"
@@ -853,6 +889,14 @@
   "simulator-gesture-send": {
     "defaultMessage": "发送手势",
     "description": "Aria label for the simulator gesture send button"
+  },
+  "simulator-gesture-shake": {
+    "defaultMessage": "shake",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-up": {
+    "defaultMessage": "up",
+    "description": "Simulator gesture option"
   },
   "simulator-hide": {
     "defaultMessage": "隐藏模拟器",

--- a/lang/ui.zh-tw.json
+++ b/lang/ui.zh-tw.json
@@ -846,6 +846,42 @@
     "defaultMessage": "展開 {title} 模組",
     "description": "Aria label for expand simulator module button"
   },
+  "simulator-gesture-3g": {
+    "defaultMessage": "3g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-6g": {
+    "defaultMessage": "6g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-8g": {
+    "defaultMessage": "8g",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-down": {
+    "defaultMessage": "down",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-face-down": {
+    "defaultMessage": "face down",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-face-up": {
+    "defaultMessage": "face up",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-freefall": {
+    "defaultMessage": "freefall",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-left": {
+    "defaultMessage": "left",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-right": {
+    "defaultMessage": "right",
+    "description": "Simulator gesture option"
+  },
   "simulator-gesture-select": {
     "defaultMessage": "選擇手勢",
     "description": "Aria label for the simulator gesture select input"
@@ -853,6 +889,14 @@
   "simulator-gesture-send": {
     "defaultMessage": "傳送手勢",
     "description": "Aria label for the simulator gesture send button"
+  },
+  "simulator-gesture-shake": {
+    "defaultMessage": "shake",
+    "description": "Simulator gesture option"
+  },
+  "simulator-gesture-up": {
+    "defaultMessage": "up",
+    "description": "Simulator gesture option"
   },
   "simulator-hide": {
     "defaultMessage": "隱藏模擬器",

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -1925,6 +1925,60 @@
       "value": " module"
     }
   ],
+  "simulator-gesture-3g": [
+    {
+      "type": 0,
+      "value": "3g"
+    }
+  ],
+  "simulator-gesture-6g": [
+    {
+      "type": 0,
+      "value": "6g"
+    }
+  ],
+  "simulator-gesture-8g": [
+    {
+      "type": 0,
+      "value": "8g"
+    }
+  ],
+  "simulator-gesture-down": [
+    {
+      "type": 0,
+      "value": "down"
+    }
+  ],
+  "simulator-gesture-face-down": [
+    {
+      "type": 0,
+      "value": "face down"
+    }
+  ],
+  "simulator-gesture-face-up": [
+    {
+      "type": 0,
+      "value": "face up"
+    }
+  ],
+  "simulator-gesture-freefall": [
+    {
+      "type": 0,
+      "value": "freefall"
+    }
+  ],
+  "simulator-gesture-left": [
+    {
+      "type": 0,
+      "value": "left"
+    }
+  ],
+  "simulator-gesture-right": [
+    {
+      "type": 0,
+      "value": "right"
+    }
+  ],
   "simulator-gesture-select": [
     {
       "type": 0,
@@ -1935,6 +1989,18 @@
     {
       "type": 0,
       "value": "Send gesture"
+    }
+  ],
+  "simulator-gesture-shake": [
+    {
+      "type": 0,
+      "value": "shake"
+    }
+  ],
+  "simulator-gesture-up": [
+    {
+      "type": 0,
+      "value": "up"
     }
   ],
   "simulator-hide": [

--- a/src/messages/ui.es-es.json
+++ b/src/messages/ui.es-es.json
@@ -1917,6 +1917,60 @@
       "value": "title"
     }
   ],
+  "simulator-gesture-3g": [
+    {
+      "type": 0,
+      "value": "3g"
+    }
+  ],
+  "simulator-gesture-6g": [
+    {
+      "type": 0,
+      "value": "6g"
+    }
+  ],
+  "simulator-gesture-8g": [
+    {
+      "type": 0,
+      "value": "8g"
+    }
+  ],
+  "simulator-gesture-down": [
+    {
+      "type": 0,
+      "value": "down"
+    }
+  ],
+  "simulator-gesture-face-down": [
+    {
+      "type": 0,
+      "value": "face down"
+    }
+  ],
+  "simulator-gesture-face-up": [
+    {
+      "type": 0,
+      "value": "face up"
+    }
+  ],
+  "simulator-gesture-freefall": [
+    {
+      "type": 0,
+      "value": "freefall"
+    }
+  ],
+  "simulator-gesture-left": [
+    {
+      "type": 0,
+      "value": "left"
+    }
+  ],
+  "simulator-gesture-right": [
+    {
+      "type": 0,
+      "value": "right"
+    }
+  ],
   "simulator-gesture-select": [
     {
       "type": 0,
@@ -1927,6 +1981,18 @@
     {
       "type": 0,
       "value": "Enviar gesto"
+    }
+  ],
+  "simulator-gesture-shake": [
+    {
+      "type": 0,
+      "value": "shake"
+    }
+  ],
+  "simulator-gesture-up": [
+    {
+      "type": 0,
+      "value": "up"
     }
   ],
   "simulator-hide": [

--- a/src/messages/ui.fr.json
+++ b/src/messages/ui.fr.json
@@ -1917,6 +1917,60 @@
       "value": "title"
     }
   ],
+  "simulator-gesture-3g": [
+    {
+      "type": 0,
+      "value": "3g"
+    }
+  ],
+  "simulator-gesture-6g": [
+    {
+      "type": 0,
+      "value": "6g"
+    }
+  ],
+  "simulator-gesture-8g": [
+    {
+      "type": 0,
+      "value": "8g"
+    }
+  ],
+  "simulator-gesture-down": [
+    {
+      "type": 0,
+      "value": "down"
+    }
+  ],
+  "simulator-gesture-face-down": [
+    {
+      "type": 0,
+      "value": "face down"
+    }
+  ],
+  "simulator-gesture-face-up": [
+    {
+      "type": 0,
+      "value": "face up"
+    }
+  ],
+  "simulator-gesture-freefall": [
+    {
+      "type": 0,
+      "value": "freefall"
+    }
+  ],
+  "simulator-gesture-left": [
+    {
+      "type": 0,
+      "value": "left"
+    }
+  ],
+  "simulator-gesture-right": [
+    {
+      "type": 0,
+      "value": "right"
+    }
+  ],
   "simulator-gesture-select": [
     {
       "type": 0,
@@ -1927,6 +1981,18 @@
     {
       "type": 0,
       "value": "Envoyer un geste"
+    }
+  ],
+  "simulator-gesture-shake": [
+    {
+      "type": 0,
+      "value": "shake"
+    }
+  ],
+  "simulator-gesture-up": [
+    {
+      "type": 0,
+      "value": "up"
     }
   ],
   "simulator-hide": [

--- a/src/messages/ui.ja.json
+++ b/src/messages/ui.ja.json
@@ -1899,6 +1899,60 @@
       "value": " モジュールを展開"
     }
   ],
+  "simulator-gesture-3g": [
+    {
+      "type": 0,
+      "value": "3g"
+    }
+  ],
+  "simulator-gesture-6g": [
+    {
+      "type": 0,
+      "value": "6g"
+    }
+  ],
+  "simulator-gesture-8g": [
+    {
+      "type": 0,
+      "value": "8g"
+    }
+  ],
+  "simulator-gesture-down": [
+    {
+      "type": 0,
+      "value": "down"
+    }
+  ],
+  "simulator-gesture-face-down": [
+    {
+      "type": 0,
+      "value": "face down"
+    }
+  ],
+  "simulator-gesture-face-up": [
+    {
+      "type": 0,
+      "value": "face up"
+    }
+  ],
+  "simulator-gesture-freefall": [
+    {
+      "type": 0,
+      "value": "freefall"
+    }
+  ],
+  "simulator-gesture-left": [
+    {
+      "type": 0,
+      "value": "left"
+    }
+  ],
+  "simulator-gesture-right": [
+    {
+      "type": 0,
+      "value": "right"
+    }
+  ],
   "simulator-gesture-select": [
     {
       "type": 0,
@@ -1909,6 +1963,18 @@
     {
       "type": 0,
       "value": "ジェスチャーを送信"
+    }
+  ],
+  "simulator-gesture-shake": [
+    {
+      "type": 0,
+      "value": "shake"
+    }
+  ],
+  "simulator-gesture-up": [
+    {
+      "type": 0,
+      "value": "up"
     }
   ],
   "simulator-hide": [

--- a/src/messages/ui.ko.json
+++ b/src/messages/ui.ko.json
@@ -1925,6 +1925,60 @@
       "value": " 모듈 펼치기"
     }
   ],
+  "simulator-gesture-3g": [
+    {
+      "type": 0,
+      "value": "3g"
+    }
+  ],
+  "simulator-gesture-6g": [
+    {
+      "type": 0,
+      "value": "6g"
+    }
+  ],
+  "simulator-gesture-8g": [
+    {
+      "type": 0,
+      "value": "8g"
+    }
+  ],
+  "simulator-gesture-down": [
+    {
+      "type": 0,
+      "value": "down"
+    }
+  ],
+  "simulator-gesture-face-down": [
+    {
+      "type": 0,
+      "value": "face down"
+    }
+  ],
+  "simulator-gesture-face-up": [
+    {
+      "type": 0,
+      "value": "face up"
+    }
+  ],
+  "simulator-gesture-freefall": [
+    {
+      "type": 0,
+      "value": "freefall"
+    }
+  ],
+  "simulator-gesture-left": [
+    {
+      "type": 0,
+      "value": "left"
+    }
+  ],
+  "simulator-gesture-right": [
+    {
+      "type": 0,
+      "value": "right"
+    }
+  ],
   "simulator-gesture-select": [
     {
       "type": 0,
@@ -1935,6 +1989,18 @@
     {
       "type": 0,
       "value": "제스처 전송"
+    }
+  ],
+  "simulator-gesture-shake": [
+    {
+      "type": 0,
+      "value": "shake"
+    }
+  ],
+  "simulator-gesture-up": [
+    {
+      "type": 0,
+      "value": "up"
     }
   ],
   "simulator-hide": [

--- a/src/messages/ui.zh-cn.json
+++ b/src/messages/ui.zh-cn.json
@@ -1922,6 +1922,60 @@
       "value": " 模块"
     }
   ],
+  "simulator-gesture-3g": [
+    {
+      "type": 0,
+      "value": "3g"
+    }
+  ],
+  "simulator-gesture-6g": [
+    {
+      "type": 0,
+      "value": "6g"
+    }
+  ],
+  "simulator-gesture-8g": [
+    {
+      "type": 0,
+      "value": "8g"
+    }
+  ],
+  "simulator-gesture-down": [
+    {
+      "type": 0,
+      "value": "down"
+    }
+  ],
+  "simulator-gesture-face-down": [
+    {
+      "type": 0,
+      "value": "face down"
+    }
+  ],
+  "simulator-gesture-face-up": [
+    {
+      "type": 0,
+      "value": "face up"
+    }
+  ],
+  "simulator-gesture-freefall": [
+    {
+      "type": 0,
+      "value": "freefall"
+    }
+  ],
+  "simulator-gesture-left": [
+    {
+      "type": 0,
+      "value": "left"
+    }
+  ],
+  "simulator-gesture-right": [
+    {
+      "type": 0,
+      "value": "right"
+    }
+  ],
   "simulator-gesture-select": [
     {
       "type": 0,
@@ -1932,6 +1986,18 @@
     {
       "type": 0,
       "value": "发送手势"
+    }
+  ],
+  "simulator-gesture-shake": [
+    {
+      "type": 0,
+      "value": "shake"
+    }
+  ],
+  "simulator-gesture-up": [
+    {
+      "type": 0,
+      "value": "up"
     }
   ],
   "simulator-hide": [

--- a/src/messages/ui.zh-tw.json
+++ b/src/messages/ui.zh-tw.json
@@ -1925,6 +1925,60 @@
       "value": " 模組"
     }
   ],
+  "simulator-gesture-3g": [
+    {
+      "type": 0,
+      "value": "3g"
+    }
+  ],
+  "simulator-gesture-6g": [
+    {
+      "type": 0,
+      "value": "6g"
+    }
+  ],
+  "simulator-gesture-8g": [
+    {
+      "type": 0,
+      "value": "8g"
+    }
+  ],
+  "simulator-gesture-down": [
+    {
+      "type": 0,
+      "value": "down"
+    }
+  ],
+  "simulator-gesture-face-down": [
+    {
+      "type": 0,
+      "value": "face down"
+    }
+  ],
+  "simulator-gesture-face-up": [
+    {
+      "type": 0,
+      "value": "face up"
+    }
+  ],
+  "simulator-gesture-freefall": [
+    {
+      "type": 0,
+      "value": "freefall"
+    }
+  ],
+  "simulator-gesture-left": [
+    {
+      "type": 0,
+      "value": "left"
+    }
+  ],
+  "simulator-gesture-right": [
+    {
+      "type": 0,
+      "value": "right"
+    }
+  ],
   "simulator-gesture-select": [
     {
       "type": 0,
@@ -1935,6 +1989,18 @@
     {
       "type": 0,
       "value": "傳送手勢"
+    }
+  ],
+  "simulator-gesture-shake": [
+    {
+      "type": 0,
+      "value": "shake"
+    }
+  ],
+  "simulator-gesture-up": [
+    {
+      "type": 0,
+      "value": "up"
     }
   ],
   "simulator-hide": [

--- a/src/simulator/AccelerometerModule.tsx
+++ b/src/simulator/AccelerometerModule.tsx
@@ -113,6 +113,7 @@ const Gesture = ({ icon, state, enabled, onValueChange }: GestureProps) => {
         value={choice}
         onChange={handleSelectChange}
         ref={selectRef}
+        fontFamily="code"
       >
         {choices.map((choice) => (
           <option key={choice} value={choice}>

--- a/src/simulator/AccelerometerModule.tsx
+++ b/src/simulator/AccelerometerModule.tsx
@@ -109,7 +109,7 @@ const Gesture = ({ icon, state, enabled, onValueChange }: GestureProps) => {
       id: `simulator-gesture-${gesture.split(" ").join("-")}`,
     });
     if (translation !== gesture) {
-      gesture += ` (${translation})`;
+      return `${translation} (${gesture})`;
     }
     return gesture;
   };
@@ -123,7 +123,6 @@ const Gesture = ({ icon, state, enabled, onValueChange }: GestureProps) => {
         value={choice}
         onChange={handleSelectChange}
         ref={selectRef}
-        fontFamily="code"
       >
         {choices.map((choice) => (
           <option key={choice} value={choice}>

--- a/src/simulator/AccelerometerModule.tsx
+++ b/src/simulator/AccelerometerModule.tsx
@@ -117,7 +117,9 @@ const Gesture = ({ icon, state, enabled, onValueChange }: GestureProps) => {
       >
         {choices.map((choice) => (
           <option key={choice} value={choice}>
-            {choice}
+            {intl.formatMessage({
+              id: `simulator-gesture-${choice.split(" ").join("-")}`,
+            })}
           </option>
         ))}
       </Select>

--- a/src/simulator/AccelerometerModule.tsx
+++ b/src/simulator/AccelerometerModule.tsx
@@ -104,6 +104,16 @@ const Gesture = ({ icon, state, enabled, onValueChange }: GestureProps) => {
     }, 500);
   }, [setActive, onValueChange, choice]);
 
+  const renderOptionText = (gesture: string): string => {
+    const translation = intl.formatMessage({
+      id: `simulator-gesture-${gesture.split(" ").join("-")}`,
+    });
+    if (translation !== gesture) {
+      gesture += ` (${translation})`;
+    }
+    return gesture;
+  };
+
   return (
     <HStack spacing={3}>
       {icon}
@@ -117,9 +127,7 @@ const Gesture = ({ icon, state, enabled, onValueChange }: GestureProps) => {
       >
         {choices.map((choice) => (
           <option key={choice} value={choice}>
-            {intl.formatMessage({
-              id: `simulator-gesture-${choice.split(" ").join("-")}`,
-            })}
+            {renderOptionText(choice)}
           </option>
         ))}
       </Select>


### PR DESCRIPTION
This PR also applies the code font family to the select gesture dropdown in the Simulator.

Preparation to translate the gestures in the same way that the API names have been. E.g. "English gesture (translated gesture)".