### PR TITLE
Remove unwanted movement on expanding Reference section.

### DIFF
--- a/src/documentation/common/DocumentationContent.tsx
+++ b/src/documentation/common/DocumentationContent.tsx
@@ -154,7 +154,7 @@ const ContextualCollapse = ({
   return (
     <Collapse
       in={isExpanded}
-      startingHeight={collapseToFirstLine ? "2.0625rem" : undefined}
+      startingHeight={collapseToFirstLine ? "1.9725rem" : undefined}
     >
       <Stack spacing={3} pt={3} noOfLines={justFirstLine ? 1 : undefined}>
         <BlockContent blocks={children} serializers={serializers} />


### PR DESCRIPTION
Stops the unwanted height adjustment of the code view component on expanding and collapsing a Refence topic entry. Issue introduced in the 90% work.