### PR TITLE
Use optional chaining to prevent button reference error.

### DIFF
--- a/src/simulator/AccelerometerModule.tsx
+++ b/src/simulator/AccelerometerModule.tsx
@@ -100,7 +100,7 @@ const Gesture = ({ icon, state, enabled, onValueChange }: GestureProps) => {
     setTimeout(() => {
       setActive(false);
       onValueChange("gesture", "none");
-      buttonRef.current!.focus();
+      buttonRef.current?.focus();
     }, 500);
   }, [setActive, onValueChange, choice]);
 


### PR DESCRIPTION
This is a logged bug that appears to occur after sending a gesture to the simulator and then expand/collapsing the accelerometer module panel. This causes a re-render and the gesture button ref can be undefined. We should also not change the focus if the user's last action was to expand/collapse the module, so this seems a reasonable fix.