### PR TITLE
Avoid unwanted project persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@microbit-foundation/python-editor-v3",
+  "name": "@microbit/python-editor-v3",
   "version": "3.0.0-local",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@microbit-foundation/python-editor-v3",
+      "name": "@microbit/python-editor-v3",
       "version": "3.0.0-local",
       "license": "MIT",
       "dependencies": {

--- a/src/fs/migration.test.ts
+++ b/src/fs/migration.test.ts
@@ -7,19 +7,23 @@ import { isMigration, parseMigrationFromUrl } from "./migration";
 
 // The heart project.
 export const testMigrationUrl =
-  "http://localhost:3000/#import:#project:XQAAgACRAAAAAAAAAAA9iImmlGSt1R++5LD+ZJ36cRz46B+lhYtNRoWF0nijpaVyZlK7ACfSpeoQpgfk21st4ty06R4PEOM4sSAXBT95G3en+tghrYmE+YJp6EiYgzA9ThKkyShWq2UdvmCzqxoNfYc1wlmTqlNv/Piaz3WoSe3flvr/ItyLl0aolQlEpv4LA8A=";
+  // origin needs to match jest's testUrl
+  "http://localhost/#import:#project:XQAAgACRAAAAAAAAAAA9iImmlGSt1R++5LD+ZJ36cRz46B+lhYtNRoWF0nijpaVyZlK7ACfSpeoQpgfk21st4ty06R4PEOM4sSAXBT95G3en+tghrYmE+YJp6EiYgzA9ThKkyShWq2UdvmCzqxoNfYc1wlmTqlNv/Piaz3WoSe3flvr/ItyLl0aolQlEpv4LA8A=";
 
 describe("parseMigrationFromUrl", () => {
   it("parses valid URL", () => {
     const migration = parseMigrationFromUrl(testMigrationUrl);
     expect(migration).toEqual({
-      meta: {
-        cloudId: "microbit.org",
-        comment: "",
-        editor: "python",
-        name: "Hearts",
+      migration: {
+        meta: {
+          cloudId: "microbit.org",
+          comment: "",
+          editor: "python",
+          name: "Hearts",
+        },
+        source: `from microbit import *\r\ndisplay.show(Image.HEART)`,
       },
-      source: `from microbit import *\r\ndisplay.show(Image.HEART)`,
+      postMigrationUrl: "http://localhost/",
     });
   });
   it("undefined for nonsense", () => {


### PR DESCRIPTION
Session storage lasts for the lifetime of the tab, so we need to make sure subsequent migration URLs and iframe configurations work.

Motivated by issues with "Open in Classroom" and "Open in Python" on microbit.org.