### PR TITLE
Staging needs to invalidate python.microbit.org.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,9 @@ jobs:
         environment:
           STAGE: STAGING
           REACT_APP_STAGE: STAGING
-          STAGING_CLOUDFRONT_DISTRIBUTION_ID: "E1IW78R9PB0PD1"
+          # Ideally we'd do stage-python and python.microbit.org. For now just the latter.
+          #STAGING_CLOUDFRONT_DISTRIBUTION_ID: "E1IW78R9PB0PD1"
+          STAGING_CLOUDFRONT_DISTRIBUTION_ID: "E2ELTBTA2OFPY2"
     steps:
       - checkout
       - *restore_npm_cache


### PR DESCRIPTION
Otherwise https://python.microbit.org/v/beta won't invalidate which is the primary view on the beta content for now.