### PR TITLE
Drag and drop fixes

### DIFF
--- a/src/editor/codemirror/copypaste.ts
+++ b/src/editor/codemirror/copypaste.ts
@@ -51,9 +51,9 @@ const copyPasteHandlers = () => [
         message: pasteContext.id,
       });
 
-      const lineNumber = view.state.doc.lineAt(
-        view.state.selection.ranges[0].from
-      ).number;
+      const line = view.state.doc.lineAt(view.state.selection.ranges[0].from);
+      const lineNumber = line.number;
+      const column = view.state.selection.ranges[0].from - line.from;
 
       view.dispatch(
         calculateChanges(
@@ -61,6 +61,7 @@ const copyPasteHandlers = () => [
           pasteContext.codeWithImports,
           pasteContext.type,
           lineNumber,
+          Math.floor(column / 4),
           true
         )
       );

--- a/src/editor/codemirror/edits.test.ts
+++ b/src/editor/codemirror/edits.test.ts
@@ -481,4 +481,16 @@ describe("edits", () => {
       indentLevelHint: 1,
     });
   });
+  it("limits use of indent hint based on following line indent", () => {
+    check({
+      line: 4,
+      initial: "if True:\n\tif True:\n\t\tprint('a')\n\tprint('b')\n",
+      additional: "print('c')",
+      expected:
+        "if True:\n\tif True:\n\t\tprint('a')\n\tprint('c')\n\tprint('b')\n",
+      type: "example",
+      // By default it would indent under the if.
+      indentLevelHint: 0,
+    });
+  });
 });

--- a/src/editor/codemirror/edits.test.ts
+++ b/src/editor/codemirror/edits.test.ts
@@ -14,14 +14,14 @@ describe("edits", () => {
     additional,
     expected,
     line,
-    column,
+    indentLevelHint,
     type,
   }: {
     initial: string;
     additional: string;
     expected: string;
     line?: number;
-    column?: number;
+    indentLevelHint?: number;
     type?: CodeInsertType;
   }) => {
     // Tabs are more maintainable in the examples but we actually work with 4 space indents.
@@ -34,7 +34,13 @@ describe("edits", () => {
       extensions: [python()],
     });
     const transaction = state.update(
-      calculateChanges(state, additional, type ?? "example", line, column)
+      calculateChanges(
+        state,
+        additional,
+        type ?? "example",
+        line,
+        indentLevelHint
+      )
     );
     const actual = transaction.newDoc.sliceString(0);
     const expectedSelection = expected.indexOf("█");
@@ -407,6 +413,15 @@ describe("edits", () => {
     check({
       line: 2,
       initial: "while True:\n  \n    print('Hi')\n",
+      additional: "print('Bye')",
+      expected: "while True:\n    print('Bye')\n  \n    print('Hi')\n",
+      type: "example",
+    });
+  });
+  it("uses column to decide position", () => {
+    check({
+      line: 2,
+      initial: "while True:\n\t",
       additional: "print('Bye')",
       expected: "while True:\n    print('Bye')\n  \n    print('Hi')\n",
       type: "example",

--- a/src/editor/codemirror/edits.test.ts
+++ b/src/editor/codemirror/edits.test.ts
@@ -387,4 +387,13 @@ describe("edits", () => {
       type: "example",
     });
   });
+  it("is not misled by whitespace on blank lines", () => {
+    check({
+      line: 3,
+      initial: "while True:\n    print('Hi')\n   \n",
+      additional: "print('Bye')",
+      expected: "while True:\n    print('Hi')\n    print('Bye')\n   \n",
+      type: "example",
+    });
+  });
 });

--- a/src/editor/codemirror/edits.test.ts
+++ b/src/editor/codemirror/edits.test.ts
@@ -14,12 +14,14 @@ describe("edits", () => {
     additional,
     expected,
     line,
+    column,
     type,
   }: {
     initial: string;
     additional: string;
     expected: string;
     line?: number;
+    column?: number;
     type?: CodeInsertType;
   }) => {
     // Tabs are more maintainable in the examples but we actually work with 4 space indents.
@@ -32,7 +34,7 @@ describe("edits", () => {
       extensions: [python()],
     });
     const transaction = state.update(
-      calculateChanges(state, additional, type ?? "example", line)
+      calculateChanges(state, additional, type ?? "example", line, column)
     );
     const actual = transaction.newDoc.sliceString(0);
     const expectedSelection = expected.indexOf("█");
@@ -392,12 +394,21 @@ describe("edits", () => {
       type: "example",
     });
   });
-  it("is not misled by whitespace on blank lines", () => {
+  it("is not misled by whitespace on blank lines - 1", () => {
     check({
       line: 3,
       initial: "while True:\n    print('Hi')\n   \n",
       additional: "print('Bye')",
       expected: "while True:\n    print('Hi')\n    print('Bye')\n   \n",
+      type: "example",
+    });
+  });
+  it("is not misled by whitespace on blank lines - 2", () => {
+    check({
+      line: 2,
+      initial: "while True:\n  \n    print('Hi')\n",
+      additional: "print('Bye')",
+      expected: "while True:\n    print('Bye')\n  \n    print('Hi')\n",
       type: "example",
     });
   });

--- a/src/editor/codemirror/edits.test.ts
+++ b/src/editor/codemirror/edits.test.ts
@@ -22,6 +22,11 @@ describe("edits", () => {
     line?: number;
     type?: CodeInsertType;
   }) => {
+    // Tabs are more maintainable in the examples but we actually work with 4 space indents.
+    initial = initial.replaceAll("\t", "    ");
+    additional = additional.replaceAll("\t", "    ");
+    expected = expected.replaceAll("\t", "    ");
+
     const state = EditorState.create({
       doc: initial,
       extensions: [python()],

--- a/src/editor/codemirror/edits.ts
+++ b/src/editor/codemirror/edits.ts
@@ -258,17 +258,25 @@ const calculateNewSelection = (
  * Find the beginning of the first content line after `pos`,
  * or failing that return `pos` unchanged.
  */
-const skipWhitespaceLines = (doc: Text, pos: number): number => {
+const skipWhitespaceLines = (
+  doc: Text,
+  pos: number,
+  dir: 1 | -1 = 1
+): number => {
   let original = doc.lineAt(pos);
   let line = original;
-  while (line.text.match(/^\s*$/)) {
+  while (!line.text.trim()) {
     try {
-      line = doc.line(line.number + 1);
+      line = doc.line(line.number + dir);
     } catch {
       break;
     }
   }
-  return line.number === original.number ? pos : line.from;
+  return line.number === original.number
+    ? pos
+    : dir === 1
+    ? line.from
+    : line.to;
 };
 
 const calculateImportChangesInternal = (
@@ -389,6 +397,7 @@ const currentImports = (state: EditorState): ImportNode[] => {
 };
 
 const isInWhileTrueTree = (state: EditorState, pos: number): boolean => {
+  pos = skipWhitespaceLines(state.doc, pos, -1);
   const tree = ensureSyntaxTree(state, state.doc.length);
   if (!tree) {
     return false;

--- a/src/editor/codemirror/edits.ts
+++ b/src/editor/codemirror/edits.ts
@@ -185,6 +185,9 @@ const findIndentLevel = (
         nextNonBlankLineIndentLevel < indent &&
         indentLevelOfContainingWhileTrue(state, mainFrom) + 1 !== indent
       ) {
+        if (levelHint < nextNonBlankLineIndentLevel) {
+          return nextNonBlankLineIndentLevel;
+        }
         return levelHint;
       }
       return indent;

--- a/src/editor/codemirror/edits.ts
+++ b/src/editor/codemirror/edits.ts
@@ -153,26 +153,25 @@ export const calculateChanges = (
 };
 
 const findIndentLevel = (state: EditorState, mainFrom: number): string => {
-  let matchLine = state.doc.lineAt(mainFrom);
-  while (!matchLine.text.trim()) {
-    const next = matchLine.number - 1;
-    if (next > 0) {
-      matchLine = state.doc.line(matchLine.number - 1);
-    } else {
-      return "";
+  for (const line of preceedingLines(state, mainFrom)) {
+    const text = line.text;
+    if (text.trim()) {
+      let indent = text.match(/^(\s*)/)?.[0] ?? "";
+      // Beginning of block:
+      if (text.trim().endsWith(":")) {
+        indent += "    ";
+      }
+      return indent;
     }
   }
-  return matchLine.text.match(/^(\s*)/)?.[0] ?? "";
+  return "";
 };
 
-/**
- * Determines if the line contains any code.
- */
-const lineIsBlank = (state: EditorState, line: number): boolean => {
-  if (line <= state.doc.lines) {
-    return state.doc.line(line).text.trim() === "";
+const preceedingLines = function* (state: EditorState, from: number) {
+  const initial = state.doc.lineAt(from).number - 1;
+  for (let line = initial; line >= 1; --line) {
+    yield state.doc.line(line);
   }
-  return false;
 };
 
 const calculateNewSelection = (

--- a/src/editor/codemirror/edits.ts
+++ b/src/editor/codemirror/edits.ts
@@ -182,7 +182,8 @@ const findIndentLevel = (
       } else if (
         levelHint !== undefined &&
         levelHint < indent &&
-        nextNonBlankLineIndentLevel < indent
+        nextNonBlankLineIndentLevel < indent &&
+        indentLevelOfContainingWhileTrue(state, mainFrom) + 1 !== indent
       ) {
         return levelHint;
       }
@@ -397,10 +398,17 @@ const currentImports = (state: EditorState): ImportNode[] => {
 };
 
 const isInWhileTrueTree = (state: EditorState, pos: number): boolean => {
+  return indentLevelOfContainingWhileTrue(state, pos) !== -1;
+};
+
+const indentLevelOfContainingWhileTrue = (
+  state: EditorState,
+  pos: number
+): number => {
   pos = skipWhitespaceLines(state.doc, pos, -1);
   const tree = ensureSyntaxTree(state, state.doc.length);
   if (!tree) {
-    return false;
+    return -1;
   }
   let done = false;
   for (const cursor = tree.cursor(pos, 0); !done; done = !cursor.parent()) {
@@ -410,11 +418,11 @@ const isInWhileTrueTree = (state: EditorState, pos: number): boolean => {
         maybeTrueNode?.type.name === "Boolean" &&
         state.sliceDoc(maybeTrueNode.from, maybeTrueNode.to) === "True"
       ) {
-        return true;
+        return indentLevel(state.doc.lineAt(cursor.from).text);
       }
     }
   }
-  return false;
+  return -1;
 };
 
 const topLevelImports = (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
- Default to appending to existing blocks but allow control over the indent level where it can't cause invalid indentation.
- Fix handling of whitespace in "while smooshing"

Closes https://github.com/microbit-foundation/python-editor-v3/issues/856.
Closes https://github.com/microbit-foundation/python-editor-v3/issues/812.
Closes https://github.com/microbit-foundation/python-editor-v3/issues/800.
Closes https://github.com/microbit-foundation/python-editor-v3/issues/539.

Concerns:
- As we don't detect intent level this weds us further to 4 space indents. Easily generalised if we did autodetect or have a preference in future. I think if you do either you need to do both though. Code structure highlighting is enabled by default and looks very poor if you don't follow the convention so I think this is OK. Likewise the autoindent and tab behaviours.
- Build change to allow iterating over generators. Needs a quick check in supported browsers but really should be fine.