### PR TITLE
Fix RangeError due to stale signature help tooltips

### DIFF
--- a/src/editor/codemirror/language-server/signatureHelp.ts
+++ b/src/editor/codemirror/language-server/signatureHelp.ts
@@ -134,7 +134,6 @@ export const signatureHelp = (
     provide: (f) =>
       showTooltip.from(f, (val) => {
         const { result, pos } = val;
-        console.log(result, pos);
         if (result) {
           return {
             pos,

--- a/src/editor/codemirror/language-server/signatureHelp.ts
+++ b/src/editor/codemirror/language-server/signatureHelp.ts
@@ -122,9 +122,6 @@ export const signatureHelp = (
       for (const effect of tr.effects) {
         if (effect.is(setSignatureHelpRequestPosition)) {
           pos = effect.value;
-          if (pos === -1) {
-            result = null;
-          }
         } else if (effect.is(setSignatureHelpResult)) {
           result = effect.value;
           if (result === null) {
@@ -132,6 +129,10 @@ export const signatureHelp = (
             pos = -1;
           }
         }
+      }
+      // Even if we just got a result, if the position has been cleared we don't want it.
+      if (pos === -1) {
+        result = null;
       }
 
       pos = pos === -1 ? -1 : tr.changes.mapPos(pos);

--- a/src/editor/codemirror/language-server/signatureHelp.ts
+++ b/src/editor/codemirror/language-server/signatureHelp.ts
@@ -81,7 +81,7 @@ const triggerSignatureHelpRequest = async (
   };
   try {
     // Must happen before other event handling that might dispatch more
-    // changes thatt invalidate our position.
+    // changes that invalidate our position.
     queueMicrotask(() => {
       view.dispatch({
         effects: [setSignatureHelpRequestPosition.of(pos)],
@@ -118,8 +118,7 @@ export const signatureHelp = (
       result: null,
     }),
     update(state, tr) {
-      let pos = state.pos;
-      let result = state.result;
+      let { pos, result } = state;
       for (const effect of tr.effects) {
         if (effect.is(setSignatureHelpRequestPosition)) {
           pos = effect.value;

--- a/src/editor/codemirror/language-server/signatureHelp.ts
+++ b/src/editor/codemirror/language-server/signatureHelp.ts
@@ -126,6 +126,10 @@ export const signatureHelp = (
           }
         }
       }
+      if (state.pos === pos && state.result === result) {
+        // Avoid pointless tooltip updates. If nothing else it makes e2e tests hard.
+        return state;
+      }
       return {
         pos,
         result,

--- a/src/editor/codemirror/language-server/signatureHelp.ts
+++ b/src/editor/codemirror/language-server/signatureHelp.ts
@@ -114,7 +114,6 @@ export const signatureHelp = (
     }),
     update(state, tr) {
       let pos = state.pos === -1 ? -1 : tr.changes.mapPos(state.pos);
-      console.log(state.pos, pos);
       let result = state.result;
       for (const effect of tr.effects) {
         if (effect.is(setSignatureHelpRequestPosition)) {

--- a/src/editor/codemirror/lint/editingLine.ts
+++ b/src/editor/codemirror/lint/editingLine.ts
@@ -34,11 +34,11 @@ export const editingLinePlugin = ViewPlugin.fromClass(
         if (!foundEditOnLine && doc.lineAt(fromB).number === selectionLine) {
           foundEditOnLine = true;
           clearTimeout(this.timeout);
-          setTimeout(() => {
+          queueMicrotask(() => {
             update.view.dispatch({
               effects: [setEditingLineEffect.of(selectionLine)],
             });
-          }, 0);
+          });
           this.timeout = setTimeout(() => {
             update.view.dispatch({
               effects: [setEditingLineEffect.of(undefined)],
@@ -51,11 +51,11 @@ export const editingLinePlugin = ViewPlugin.fromClass(
         update.state.field(editingLineState) !== selectionLine
       ) {
         clearTimeout(this.timeout);
-        setTimeout(() => {
+        queueMicrotask(() => {
           update.view.dispatch({
             effects: [setEditingLineEffect.of(undefined)],
           });
-        }, 0);
+        });
       }
     }
 


### PR DESCRIPTION
It now maps the position through so you see lagged tooltips if Pyright responses are slow rather than tooltips for positions that might not be in the document at all.