### PR TITLE
Signature help fix tweak.

### DIFF
--- a/src/editor/codemirror/language-server/signatureHelp.ts
+++ b/src/editor/codemirror/language-server/signatureHelp.ts
@@ -317,11 +317,11 @@ export const signatureHelp = (
           !event.relatedTarget.closest(".cm-signature-tooltip")
         ) {
           // This can be called inside an update.
-          setTimeout(() => {
+          queueMicrotask(() => {
             view.dispatch({
               effects: setSignatureHelpRequestPosition.of(-1),
             });
-          }, 0);
+          });
         }
       },
     }),


### PR DESCRIPTION
Close the signature help while we know the view is still good. Alternatively we could cancel the timeout but this is OK too. I can't see simple API to check that a view is still good to interact with after an async step.