### PR TITLE
WebUSB: On serial connection check baud rate before setting it.

### DIFF
--- a/src/device/dap-wrapper.ts
+++ b/src/device/dap-wrapper.ts
@@ -112,7 +112,11 @@ export class DAPWrapper {
   }
 
   async startSerial(listener: (data: string) => void): Promise<void> {
-    await this.daplink.setSerialBaudrate(115200);
+    const currentBaud = await this.daplink.getSerialBaudrate();
+    if (currentBaud !== 115200) {
+      // Changing the baud rate causes a micro:bit reset, so only do it if necessary
+      await this.daplink.setSerialBaudrate(115200);
+    }
     this.daplink.on(DAPLink.EVENT_SERIAL_DATA, listener);
     await this.daplink.startSerialRead(1);
   }


### PR DESCRIPTION
Setting the baud rate makes DAPLink send a "break signal", which basically resets the target.

This is noticeable to the Python Editor users when switching tabs as it makes their programme reset.

We can avoid this reset by checking first the DAPLink serial settings and only set the baud rate if necessary.

For devices with DAPLink 0257 and newer (V2.2) the default baud rate is set to 115200 already, so they will never reset on WebUSB connection. For devices with older DAPLink versions (V1 and V2.00) the editor will set the baud rate on first connection (triggering a reset), but won't have to set it again until the device is unplugged.

I tried to replicate the `Bad response for 8 -> 17` issue for about 5 minutes changing tabs and refreshing-and-reconnecting and it seems fine (and also checked that it's really easy to replicate in the Python Editor v2).
- https://github.com/microbit-foundation/python-editor-v3/issues/89
