### PR TITLE
Mark deployment steps as foundation-only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,7 @@ jobs:
       REVIEW_CLOUDFRONT_DISTRIBUTION_ID: E3267W09ZJHQG9
 
     steps:
-      # Note: This workflow will not run on forks without modification; we're open to making steps
-      #       that reply on our deployment infrastructure conditional. Please open an issue.
+      # Note: This workflow disables deployment steps and micro:bit branding installation on forks.
       - uses: actions/checkout@v3
       - name: Configure node
         uses: actions/setup-node@v3
@@ -37,11 +36,13 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm install --no-save @microbit-foundation/python-editor-v3-microbit@0.1.0-dev.198 @microbit-foundation/website-deploy-aws@0.3.0 @microbit-foundation/website-deploy-aws-config@0.7.1 @microbit-foundation/circleci-npm-package-versioner@1
+        if: github.repository_owner == 'microbit-foundation'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: node ./bin/print-ci-env-stage.js >> $GITHUB_ENV
       - run: node ./bin/print-ci-env-public-url.js >> $GITHUB_ENV
       - run: npm run ci:update-version
+        if: github.repository_owner == 'microbit-foundation'
       - run: npm run ci
         env:
           REACT_APP_GA_MEASUREMENT_ID: ${{ secrets.GA_MEASUREMENT_ID }}
@@ -58,10 +59,12 @@ jobs:
           name: reports
           path: reports/
       - run: npm run deploy
+        if: github.repository_owner == 'microbit-foundation'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.WEB_DEPLOY_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.WEB_DEPLOY_AWS_SECRET_ACCESS_KEY }}
       - run: npm run invalidate
+        if: github.repository_owner == 'microbit-foundation'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.WEB_DEPLOY_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.WEB_DEPLOY_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/pr-url.yml
+++ b/.github/workflows/pr-url.yml
@@ -4,6 +4,7 @@ on:
     types: [opened]
 jobs:
   pr-url:
+    if: github.repository_owner == 'microbit-foundation'
     runs-on: ubuntu-latest
     steps:
       - uses: microbit-foundation/action-pr-url-template@v0.1.2

--- a/bin/print-ci-env-public-url.js
+++ b/bin/print-ci-env-public-url.js
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
-// STAGE must be defined before this is imported
-const { bucketPrefix } = require("../deployment");
-
+let url;
+if (process.env.GITHUB_REPOSITORY_OWNER === "microbit-foundation") {
+  // STAGE must be defined before this is imported
+  const { bucketPrefix } = require("../deployment");
+  url = `/${bucketPrefix}/`;
+} else {
+  url = "/";
+}
 // Two env vars as PUBLIC_URL seems to be blank when running jest even if we set it.
-console.log(`PUBLIC_URL=/${bucketPrefix}/`);
-console.log(`E2E_PUBLIC_URL=/${bucketPrefix}/`);
+console.log(`PUBLIC_URL=${url}`);
+console.log(`E2E_PUBLIC_URL=${url}`);


### PR DESCRIPTION
Aim for the moment is for forks to be able to run all the tests.
GH pages might be a nice option in future.