### PR TITLE
Avoid resetting serial terminal when possible

### DIFF
--- a/src/device/device.ts
+++ b/src/device/device.ts
@@ -129,8 +129,23 @@ export interface FlashDataSource {
   files(): Promise<Record<string, Uint8Array>>;
 }
 
+export const enum SerialOption {
+  /**
+   * Don't read serial data.
+   */
+  None,
+  /**
+   * Emit a reset to clear any listeners, then read serial data.
+   */
+  Reset,
+  /**
+   * Read serial data. No reset is emitted.
+   */
+  NoReset,
+}
+
 export interface ConnectOptions {
-  serial?: boolean;
+  serial: SerialOption;
 }
 
 export interface DeviceConnection extends EventEmitter {

--- a/src/project/project-actions.tsx
+++ b/src/project/project-actions.tsx
@@ -24,6 +24,7 @@ import {
   DeviceConnection,
   EVENT_END_USB_SELECT,
   HexGenerationError,
+  SerialOption,
   WebUSBError,
   WebUSBErrorCode,
 } from "../device/device";
@@ -131,7 +132,12 @@ export class ProjectActions {
     } else {
       if (await this.showConnectHelp(forceConnectHelp, finalFocusRef)) {
         return this.connectInternal(
-          { serial: userAction !== ConnectionAction.FLASH },
+          {
+            serial:
+              userAction === ConnectionAction.FLASH
+                ? SerialOption.None
+                : SerialOption.Reset,
+          },
           userAction,
           finalFocusRef
         );

--- a/src/serial/SerialArea.tsx
+++ b/src/serial/SerialArea.tsx
@@ -53,31 +53,31 @@ const SerialArea = ({
         position="relative"
         overflow="hidden"
       >
-        {!connected ? null : (
-          <Box
-            alignItems="stretch"
-            backgroundColor={backgroundColorTerm}
-            height="100%"
-          >
-            <SerialBar
-              height={12}
-              compact={compact}
-              onSizeChange={onSizeChange}
-              showSyncStatus={showSyncStatus}
-              expandDirection={expandDirection}
-              hideExpandTextOnTraceback={hideExpandTextOnTraceback}
-              showHintsAndTips={showHintsAndTips}
-            />
-            <XTerm
-              visibility={compact ? "hidden" : undefined}
-              height={`calc(100% - ${SerialArea.compactSize}px)`}
-              ml={1}
-              mr={1}
-              fontSizePt={terminalFontSizePt}
-              tabOutRef={tabOutRef}
-            />
-          </Box>
-        )}
+        <Box
+          // Need to render this when not connected as we need it to maintain scrollback across disconnect/reconnect in some cases.
+          display={connected ? undefined : "none"}
+          alignItems="stretch"
+          backgroundColor={backgroundColorTerm}
+          height="100%"
+        >
+          <SerialBar
+            height={12}
+            compact={compact}
+            onSizeChange={onSizeChange}
+            showSyncStatus={showSyncStatus}
+            expandDirection={expandDirection}
+            hideExpandTextOnTraceback={hideExpandTextOnTraceback}
+            showHintsAndTips={showHintsAndTips}
+          />
+          <XTerm
+            visibility={compact ? "hidden" : undefined}
+            height={`calc(100% - ${SerialArea.compactSize}px)`}
+            ml={1}
+            mr={1}
+            fontSizePt={terminalFontSizePt}
+            tabOutRef={tabOutRef}
+          />
+        </Box>
       </Flex>
     </TerminalContext>
   );


### PR DESCRIPTION
Follow up to ca1f325b23cd5cbf5451cca22e94f3f245a73f3f

This aims to avoid EVENT_RESET when its due to the workaround we have in place that disconnects background tabs.