### PR TITLE
Deploy/invalidate REVIEW stage even if e2e fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,12 +59,12 @@ jobs:
           name: reports
           path: reports/
       - run: npm run deploy
-        if: github.repository_owner == 'microbit-foundation'
+        if: github.repository_owner == 'microbit-foundation' && (env.STAGE == 'REVIEW' || success())
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.WEB_DEPLOY_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.WEB_DEPLOY_AWS_SECRET_ACCESS_KEY }}
       - run: npm run invalidate
-        if: github.repository_owner == 'microbit-foundation'
+        if: github.repository_owner == 'microbit-foundation' && (env.STAGE == 'REVIEW' || success())
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.WEB_DEPLOY_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.WEB_DEPLOY_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Often looking at that deployment is the quickest way to understand a failure.