### PR TITLE
Fix auto-complete layout at narrow widths

### DIFF
--- a/src/editor/codemirror/themeExtensions.ts
+++ b/src/editor/codemirror/themeExtensions.ts
@@ -77,8 +77,18 @@ export const themeExtensions = (fontSize: string) => {
     ".cm-tooltip.cm-completionInfo.cm-completionInfo-right": {
       borderLeft: "none",
     },
+    ".cm-tooltip.cm-completionInfo.cm-completionInfo-right-narrow": {
+      position: "relative",
+      left: 0,
+      maxWidth: "unset !important",
+    },
     ".cm-tooltip.cm-completionInfo.cm-completionInfo-left": {
       borderRight: "none",
+    },
+    ".cm-tooltip.cm-completionInfo.cm-completionInfo-left-narrow": {
+      position: "relative",
+      left: 0,
+      maxWidth: "unset !important",
     },
     ".cm-tooltip.cm-completionInfo": {
       width: "20rem",


### PR DESCRIPTION
Flips the auto-complete layout to vertical at narrow screen widths. VS Code takes this approach.

See https://support.microbit.org/helpdesk/tickets/66169 (private).