### PR TITLE
Add flag to hide language setting menu

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -32,7 +32,14 @@ export type Flag =
    * Added to support user-testing and has the nice side-effect of disabling
    * the dialog for local development so is worth keeping for that use alone.
    */
-  | "noWelcome";
+  | "noWelcome"
+  /**
+   * Disables language selection from the settings menu.
+   *
+   * Added so we can embed the editor in micro:bit classroom without competing language
+   * options. The language selected in classroom is passed through via query param.
+   */
+  | "noLang";
 
 interface FlagMetadata {
   defaultOnStages: Stage[];
@@ -44,6 +51,7 @@ const allFlags: FlagMetadata[] = [
   { name: "dndDebug", defaultOnStages: [] },
   { name: "betaNotice", defaultOnStages: ["local", "REVIEW", "STAGING"] },
   { name: "noWelcome", defaultOnStages: ["local", "REVIEW"] },
+  { name: "noLang", defaultOnStages: [] },
 ];
 
 type Flags = Record<Flag, boolean>;

--- a/src/settings/SettingsMenu.tsx
+++ b/src/settings/SettingsMenu.tsx
@@ -20,6 +20,7 @@ import { RiListSettingsLine, RiSettings2Line } from "react-icons/ri";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useDialogs } from "../common/use-dialogs";
 import { zIndexAboveTerminal } from "../common/zIndex";
+import { flags } from "../flags";
 import { LanguageDialog } from "./LanguageDialog";
 import { SettingsDialog } from "./SettingsDialog";
 
@@ -66,13 +67,15 @@ const SettingsMenu = ({ size, ...props }: SettingsMenuProps) => {
         />
         <Portal>
           <MenuList zIndex={zIndexAboveTerminal}>
-            <MenuItem
-              icon={<IoMdGlobe />}
-              onClick={languageDisclosure.onOpen}
-              data-testid="language"
-            >
-              <FormattedMessage id="language" />
-            </MenuItem>
+            {!flags.noLang && (
+              <MenuItem
+                icon={<IoMdGlobe />}
+                onClick={languageDisclosure.onOpen}
+                data-testid="language"
+              >
+                <FormattedMessage id="language" />
+              </MenuItem>
+            )}
             <MenuItem
               icon={<RiListSettingsLine />}
               onClick={handleShowSettings}


### PR DESCRIPTION
We will use this when embedding inside micro:bit classroom to control language at the top level.