### PR TITLE
Add a limited drafts flag

### DIFF
--- a/src/documentation/reference/model.ts
+++ b/src/documentation/reference/model.ts
@@ -8,6 +8,13 @@ import { PortableText, SimpleImage, Slug } from "../../common/sanity";
 import { HasCompatibility } from "../common/model";
 
 export interface Toolkit {
+  /**
+   * The CMS internal id.
+   */
+  _id: string;
+  /**
+   * The logical id.
+   */
   id: string;
   name: string;
   description: string;

--- a/src/documentation/search/search.test.ts
+++ b/src/documentation/search/search.test.ts
@@ -101,6 +101,7 @@ describe("buildReferenceIndex", () => {
   it("uses language from the toolkit for the Reference index", async () => {
     const api: ApiDocsResponse = {};
     const referenceEn: Toolkit = {
+      _id: "asdf",
       id: "reference",
       description: "description",
       language: "en",
@@ -154,6 +155,7 @@ describe("SearchWorker", () => {
     const indexMessage: IndexMessage = {
       kind: "index",
       reference: {
+        _id: "asdf",
         id: "reference",
         description: "Reference stuff",
         name: "Reference",
@@ -185,6 +187,7 @@ describe("SearchWorker", () => {
     const emptyIndex: IndexMessage = {
       kind: "index",
       reference: {
+        _id: "asdf",
         id: "reference",
         description: "Reference stuff",
         name: "Reference",
@@ -196,6 +199,7 @@ describe("SearchWorker", () => {
     const fullIndex: IndexMessage = {
       kind: "index",
       reference: {
+        _id: "asdf",
         id: "reference",
         description: "Reference stuff",
         name: "Reference",

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -17,29 +17,33 @@ import { Stage, stage as stageFromEnvironment } from "./environment";
  */
 export type Flag =
   /**
-   * Enables verbose debug logging to the console of drag events.
-   */
-  | "dndDebug"
-
-  /**
    * Flag to add a beta notice. Enabled for staging site but not production stages.
    */
   | "betaNotice"
-
   /**
-   * Disables the pop-up welcome dialog.
-   *
-   * Added to support user-testing and has the nice side-effect of disabling
-   * the dialog for local development so is worth keeping for that use alone.
+   * Enables verbose debug logging to the console of drag events.
    */
-  | "noWelcome"
+  | "dndDebug"
+  /**
+   * Shows CMS drafts in preference to live content.
+   *
+   * Currently only supported for the reference content.
+   */
+  | "drafts"
   /**
    * Disables language selection from the settings menu.
    *
    * Added so we can embed the editor in micro:bit classroom without competing language
    * options. The language selected in classroom is passed through via query param.
    */
-  | "noLang";
+  | "noLang"
+  /**
+   * Disables the pop-up welcome dialog.
+   *
+   * Added to support user-testing and has the nice side-effect of disabling
+   * the dialog for local development so is worth keeping for that use alone.
+   */
+  | "noWelcome";
 
 interface FlagMetadata {
   defaultOnStages: Stage[];
@@ -49,6 +53,7 @@ interface FlagMetadata {
 const allFlags: FlagMetadata[] = [
   // Alphabetical order.
   { name: "dndDebug", defaultOnStages: [] },
+  { name: "drafts", defaultOnStages: ["local", "REVIEW"] },
   { name: "betaNotice", defaultOnStages: ["local", "REVIEW", "STAGING"] },
   { name: "noWelcome", defaultOnStages: ["local", "REVIEW"] },
   { name: "noLang", defaultOnStages: [] },


### PR DESCRIPTION
Good enough to view new Reference sections assuming they're published but the top-level document that adds them is a draft.