### PR TITLE
Fix serial re-init required when switching tabs

### DIFF
--- a/src/serial/XTerm.tsx
+++ b/src/serial/XTerm.tsx
@@ -47,7 +47,6 @@ const useManagedTermimal = (
   tabOutRef: HTMLElement,
   fontSizePt: number
 ): void => {
-  const parent = ref.current;
   const actionFeedback = useActionFeedback();
   const codeFontFamily = useToken("fonts", "code");
   const device = useDevice();
@@ -58,6 +57,7 @@ const useManagedTermimal = (
   const initialFontSizeRef = useRef<number>(fontSizePt);
 
   useEffect(() => {
+    const parent = ref.current;
     if (!parent) {
       return;
     }
@@ -188,11 +188,11 @@ const useManagedTermimal = (
     currentTerminalRef,
     device,
     isUnmounted,
-    parent,
     setSelection,
     fitAddon,
     initialFontSizeRef,
     tabOutRef,
+    ref,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
This moves the ref for the parent container into the useEffect call instead of copying it outside of the useEffect.