### PR TITLE
Tweak initial render of search icon

### DIFF
--- a/src/workbench/SideBarHeader.tsx
+++ b/src/workbench/SideBarHeader.tsx
@@ -138,7 +138,7 @@ const SideBarHeader = ({
   const contentRect = useResizeObserverContentRect(ref);
   const contentWidth = contentRect?.width ?? 0;
   const searchButtonMode =
-    !contentWidth || contentWidth > 405 ? "button" : "icon";
+    contentWidth && contentWidth > 405 ? "button" : "icon";
   const paddingX = 14;
   const modalOffset = faceLogoRef.current
     ? faceLogoRef.current.getBoundingClientRect().right + paddingX


### PR DESCRIPTION
This sidesteps a visual change since the React 18 upgrade. The default sidebar width is always the right width for the icon presentation.