### PR TITLE
Allow SW scope without a trailing slash

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -93,6 +93,11 @@ export default defineConfig(({ mode }) => {
       VitePWA({
         disable: !featurePwa,
         registerType: "autoUpdate",
+        // Remove the trailing slash so we can serve from e.g. /v/3 not just /v/3/
+        // This requires the corresponding service-worker-allowed header to be set.
+        // URLs are prefix matched so it's a compromise solution that could affect other
+        // paths sharing the same prefix
+        scope: process.env.BASE_URL.replace(/\/$/, ""),
         workbox: {
           cacheId: pwaCacheId,
           // Only precache language assets for the fallback language.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -97,7 +97,7 @@ export default defineConfig(({ mode }) => {
         // This requires the corresponding service-worker-allowed header to be set.
         // URLs are prefix matched so it's a compromise solution that could affect other
         // paths sharing the same prefix
-        scope: process.env.BASE_URL.replace(/\/$/, ""),
+        scope: process.env.BASE_URL?.replace(/\/$/, ""),
         workbox: {
           cacheId: pwaCacheId,
           // Only precache language assets for the fallback language.


### PR DESCRIPTION
This is something of a compromise and requires a header.

## TODO
- [x] Test on review
- [x] Add header on staging
- [ ] Merge
- [ ] Test on staging
- [x] Add header on production (if different from staging)