### PR TITLE
Use EventTarget rather than the Node "events" module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "crelt": "^1.0.5",
         "dapjs": "2.2.0",
         "dompurify": "^2.3.3",
-        "events": "^3.3.0",
         "file-saver": "^2.0.5",
         "framer-motion": "^10.2.4",
         "lodash.debounce": "^4.0.8",
@@ -7491,14 +7490,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "engines": {
-        "node": ">=0.8.x"
       }
     },
     "node_modules/execa": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "crelt": "^1.0.5",
     "dapjs": "2.2.0",
     "dompurify": "^2.3.3",
-    "events": "^3.3.0",
     "file-saver": "^2.0.5",
     "framer-motion": "^10.2.4",
     "lodash.debounce": "^4.0.8",

--- a/src/common/events.ts
+++ b/src/common/events.ts
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2022 Jonas "DerZade" Schade
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * https://github.com/DerZade/typescript-event-target/blob/master/src/TypedEventTarget.ts
+ */
+
+/**
+ * A function that can be passed to the `listener` parameter of {@link TypedEventTarget.addEventListener} and {@link TypedEventTarget.removeEventListener}.
+ *
+ * @template M A map of event types to their respective event classes.
+ * @template T The type of event to listen for (has to be keyof `M`).
+ */
+export type TypedEventListener<M, T extends keyof M> = (
+  evt: M[T]
+) => void | Promise<void>;
+
+/**
+ * An object that can be passed to the `listener` parameter of {@link TypedEventTarget.addEventListener} and {@link TypedEventTarget.removeEventListener}.
+ *
+ * @template M A map of event types to their respective event classes.
+ * @template T The type of event to listen for (has to be keyof `M`).
+ */
+export interface TypedEventListenerObject<M, T extends keyof M> {
+  handleEvent: (evt: M[T]) => void | Promise<void>;
+}
+
+/**
+ * Type of parameter `listener` in {@link TypedEventTarget.addEventListener} and {@link TypedEventTarget.removeEventListener}.
+ *
+ * The object that receives a notification (an object that implements the Event interface) when an event of the specified type occurs.
+ *
+ * Can be either an object with a handleEvent() method, or a JavaScript function.
+ *
+ * @template M A map of event types to their respective event classes.
+ * @template T The type of event to listen for (has to be keyof `M`).
+ */
+export type TypedEventListenerOrEventListenerObject<M, T extends keyof M> =
+  | TypedEventListener<M, T>
+  | TypedEventListenerObject<M, T>;
+
+type ValueIsEvent<T> = {
+  [key in keyof T]: Event;
+};
+
+/**
+ * Typescript friendly version of {@link EventTarget}
+ *
+ * @template M A map of event types to their respective event classes.
+ *
+ * @example
+ * ```typescript
+ * interface MyEventMap {
+ *     hello: Event;
+ *     time: CustomEvent<number>;
+ * }
+ *
+ * const eventTarget = new TypedEventTarget<MyEventMap>();
+ *
+ * eventTarget.addEventListener('time', (event) => {
+ *     // event is of type CustomEvent<number>
+ * });
+ * ```
+ */
+export interface TypedEventTarget<M extends ValueIsEvent<M>> {
+  /** Appends an event listener for events whose type attribute value is type.
+   * The callback argument sets the callback that will be invoked when the event
+   * is dispatched.
+   *
+   * The options argument sets listener-specific options. For compatibility this
+   * can be a boolean, in which case the method behaves exactly as if the value
+   * was specified as options's capture.
+   *
+   * When set to true, options's capture prevents callback from being invoked
+   * when the event's eventPhase attribute value is BUBBLING_PHASE. When false
+   * (or not present), callback will not be invoked when event's eventPhase
+   * attribute value is CAPTURING_PHASE. Either way, callback will be invoked if
+   * event's eventPhase attribute value is AT_TARGET.
+   *
+   * When set to true, options's passive indicates that the callback will not
+   * cancel the event by invoking preventDefault(). This is used to enable
+   * performance optimizations described in § 2.8 Observing event listeners.
+   *
+   * When set to true, options's once indicates that the callback will only be
+   * invoked once after which the event listener will be removed.
+   *
+   * The event listener is appended to target's event listener list and is not
+   * appended if it has the same type, callback, and capture. */
+  addEventListener: <T extends keyof M & string>(
+    type: T,
+    listener: TypedEventListenerOrEventListenerObject<M, T> | null,
+    options?: boolean | AddEventListenerOptions
+  ) => void;
+
+  /** Removes the event listener in target's event listener list with the same
+   * type, callback, and options. */
+  removeEventListener: <T extends keyof M & string>(
+    type: T,
+    callback: TypedEventListenerOrEventListenerObject<M, T> | null,
+    options?: EventListenerOptions | boolean
+  ) => void;
+
+  /**
+   * Dispatches a synthetic event event to target and returns true if either
+   * event's cancelable attribute value is false or its preventDefault() method
+   * was not invoked, and false otherwise.
+   * @deprecated To ensure type safety use `dispatchTypedEvent` instead.
+   */
+  dispatchEvent: (event: Event) => boolean;
+}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class TypedEventTarget<M extends ValueIsEvent<M>> extends EventTarget {
+  /**
+   * Dispatches a synthetic event event to target and returns true if either
+   * event's cancelable attribute value is false or its preventDefault() method
+   * was not invoked, and false otherwise.
+   */
+  public dispatchTypedEvent<T extends keyof M>(_type: T, event: M[T]): boolean {
+    return super.dispatchEvent(event);
+  }
+}

--- a/src/device/device-hooks.tsx
+++ b/src/device/device-hooks.tsx
@@ -16,13 +16,8 @@ import { useLogging } from "../logging/logging-hooks";
 import {
   ConnectionStatus,
   DeviceConnection,
-  EVENT_FLASH,
-  EVENT_SERIAL_DATA,
-  EVENT_SERIAL_ERROR,
-  EVENT_SERIAL_RESET,
-  EVENT_STATUS,
   SerialDataEvent,
-  StatusEvent,
+  ConnectionStatusEvent,
 } from "./device";
 import { SimulatorDeviceConnection } from "./simulator";
 
@@ -61,12 +56,12 @@ export const useConnectionStatus = () => {
   const device = useDevice();
   const [status, setStatus] = useState<ConnectionStatus>(device.status);
   useEffect(() => {
-    const statusListener = (event: StatusEvent) => {
+    const statusListener = (event: ConnectionStatusEvent) => {
       setStatus(event.status);
     };
-    device.addEventListener(EVENT_STATUS, statusListener);
+    device.addEventListener("status", statusListener);
     return () => {
-      device.removeEventListener(EVENT_STATUS, statusListener);
+      device.removeEventListener("status", statusListener);
     };
   }, [device, setStatus]);
 
@@ -205,13 +200,13 @@ export const useDeviceTraceback = () => {
       buffer.clear();
       setRuntimeError(undefined);
     };
-    device.addEventListener(EVENT_SERIAL_DATA, dataListener);
-    device.addEventListener(EVENT_SERIAL_RESET, clearListener);
-    device.addEventListener(EVENT_SERIAL_ERROR, clearListener);
+    device.addEventListener("serial_data", dataListener);
+    device.addEventListener("serial_reset", clearListener);
+    device.addEventListener("serial_error", clearListener);
     return () => {
-      device.removeEventListener(EVENT_SERIAL_ERROR, clearListener);
-      device.removeEventListener(EVENT_SERIAL_RESET, clearListener);
-      device.removeEventListener(EVENT_SERIAL_DATA, dataListener);
+      device.removeEventListener("serial_error", clearListener);
+      device.removeEventListener("serial_reset", clearListener);
+      device.removeEventListener("serial_data", dataListener);
     };
   }, [device, setRuntimeError, logging]);
 
@@ -250,13 +245,13 @@ export const DeviceContextProvider = ({
     const moveToInSync = () => setSyncStatus(SyncStatus.IN_SYNC);
     fs.addEventListener("file_text_updated", moveToOutOfSync);
     fs.addEventListener("project_updated", moveToOutOfSync);
-    device.addEventListener(EVENT_FLASH, moveToInSync);
-    device.addEventListener(EVENT_STATUS, moveToOutOfSync);
+    device.addEventListener("flash", moveToInSync);
+    device.addEventListener("status", moveToOutOfSync);
     return () => {
       fs.removeEventListener("file_text_updated", moveToOutOfSync);
       fs.removeEventListener("project_updated", moveToOutOfSync);
-      device.removeEventListener(EVENT_STATUS, moveToOutOfSync);
-      device.removeEventListener(EVENT_FLASH, moveToInSync);
+      device.removeEventListener("status", moveToOutOfSync);
+      device.removeEventListener("flash", moveToInSync);
     };
   }, [fs, device, setSyncStatus]);
   return (

--- a/src/device/device.ts
+++ b/src/device/device.ts
@@ -96,14 +96,6 @@ export enum ConnectionAction {
   DISCONNECT = "DISCONNECT",
 }
 
-export const EVENT_STATUS = "status";
-export const EVENT_SERIAL_DATA = "serial_data";
-export const EVENT_SERIAL_RESET = "serial_reset";
-export const EVENT_SERIAL_ERROR = "serial_error";
-export const EVENT_FLASH = "flash";
-export const EVENT_START_USB_SELECT = "start_usb_select";
-export const EVENT_END_USB_SELECT = "end_usb_select";
-
 export class HexGenerationError extends Error {}
 
 export interface FlashDataSource {
@@ -135,7 +127,7 @@ export interface ConnectOptions {
 
 export type BoardVersion = "V1" | "V2";
 
-export class StatusEvent extends Event {
+export class ConnectionStatusEvent extends Event {
   constructor(public readonly status: ConnectionStatus) {
     super("status");
   }
@@ -173,12 +165,12 @@ export class StartUSBSelect extends Event {
 
 export class EndUSBSelect extends Event {
   constructor() {
-    super("start_usb_select");
+    super("end_usb_select");
   }
 }
 
 export class DeviceConnectionEventMap {
-  "status": StatusEvent;
+  "status": ConnectionStatusEvent;
   "serial_data": SerialDataEvent;
   "serial_reset": Event;
   "serial_error": Event;

--- a/src/device/device.ts
+++ b/src/device/device.ts
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import EventEmitter from "events";
+import { TypedEventTarget } from "../common/events";
 import { Logging } from "../logging/logging";
 import { BoardId } from "./board-id";
 
@@ -135,7 +135,60 @@ export interface ConnectOptions {
 
 export type BoardVersion = "V1" | "V2";
 
-export interface DeviceConnection extends EventEmitter {
+export class StatusEvent extends Event {
+  constructor(public readonly status: ConnectionStatus) {
+    super("status");
+  }
+}
+
+export class SerialDataEvent extends Event {
+  constructor(public readonly data: string) {
+    super("serial_data");
+  }
+}
+
+export class SerialResetEvent extends Event {
+  constructor() {
+    super("serial_reset");
+  }
+}
+
+export class SerialErrorEvent extends Event {
+  constructor(public readonly error: unknown) {
+    super("serial_error");
+  }
+}
+
+export class FlashEvent extends Event {
+  constructor() {
+    super("flash");
+  }
+}
+
+export class StartUSBSelect extends Event {
+  constructor() {
+    super("start_usb_select");
+  }
+}
+
+export class EndUSBSelect extends Event {
+  constructor() {
+    super("start_usb_select");
+  }
+}
+
+export class DeviceConnectionEventMap {
+  "status": StatusEvent;
+  "serial_data": SerialDataEvent;
+  "serial_reset": Event;
+  "serial_error": Event;
+  "flash": Event;
+  "start_usb_select": Event;
+  "end_usb_select": Event;
+}
+
+export interface DeviceConnection
+  extends TypedEventTarget<DeviceConnectionEventMap> {
   status: ConnectionStatus;
 
   /**

--- a/src/device/mock.ts
+++ b/src/device/mock.ts
@@ -12,7 +12,7 @@ import {
   FlashDataSource,
   FlashEvent,
   SerialDataEvent,
-  StatusEvent,
+  ConnectionStatusEvent,
   WebUSBError,
   WebUSBErrorCode,
 } from "./device";
@@ -102,7 +102,7 @@ export class MockDeviceConnection
 
   private setStatus(newStatus: ConnectionStatus) {
     this.status = newStatus;
-    this.dispatchTypedEvent("status", new StatusEvent(this.status));
+    this.dispatchTypedEvent("status", new ConnectionStatusEvent(this.status));
   }
 
   clearDevice(): void {

--- a/src/device/simulator.ts
+++ b/src/device/simulator.ts
@@ -14,7 +14,7 @@ import {
   FlashEvent,
   SerialDataEvent,
   SerialResetEvent,
-  StatusEvent,
+  ConnectionStatusEvent,
 } from "./device";
 
 // Simulator-only events.
@@ -196,7 +196,10 @@ export class SimulatorDeviceConnection
     switch (event.data.kind) {
       case "ready": {
         this.state = event.data.state;
-        this.dispatchTypedEvent("status", new StatusEvent(this.status));
+        this.dispatchTypedEvent(
+          "status",
+          new ConnectionStatusEvent(this.status)
+        );
         if (this.status !== ConnectionStatus.CONNECTED) {
           this.setStatus(ConnectionStatus.CONNECTED);
         }
@@ -405,7 +408,7 @@ export class SimulatorDeviceConnection
 
   private setStatus(newStatus: ConnectionStatus) {
     this.status = newStatus;
-    this.dispatchTypedEvent("status", new StatusEvent(newStatus));
+    this.dispatchTypedEvent("status", new ConnectionStatusEvent(newStatus));
   }
 
   clearDevice(): void {

--- a/src/device/simulator.ts
+++ b/src/device/simulator.ts
@@ -204,7 +204,7 @@ export class SimulatorDeviceConnection
         break;
       }
       case "request_flash": {
-        this.dispatchTypedEvent("flash", new FlashEvent());
+        this.dispatchTypedEvent("request_flash", new RequestFlashEvent());
         this.logging.event({
           type: "sim-user-start",
         });

--- a/src/device/simulator.ts
+++ b/src/device/simulator.ts
@@ -195,11 +195,9 @@ export class SimulatorDeviceConnection
     }
     switch (event.data.kind) {
       case "ready": {
-        this.state = event.data.state;
-        this.dispatchTypedEvent(
-          "status",
-          new ConnectionStatusEvent(this.status)
-        );
+        const newState = event.data.state;
+        this.state = newState;
+        this.dispatchTypedEvent("state_change", new StateChangeEvent(newState));
         if (this.status !== ConnectionStatus.CONNECTED) {
           this.setStatus(ConnectionStatus.CONNECTED);
         }

--- a/src/device/webusb.test.ts
+++ b/src/device/webusb.test.ts
@@ -9,7 +9,7 @@
  * It might be we could create a custom environment that was web but
  * with a tweak to Buffer.
  */
-import { ConnectionStatus, EVENT_STATUS } from "./device";
+import { ConnectionStatus, EVENT_STATUS, StatusEvent } from "./device";
 import { NullLogging } from "../deployment/default/logging";
 import { MicrobitWebUSBConnection } from "./webusb";
 import { vi } from "vitest";
@@ -59,9 +59,9 @@ describeDeviceOnly("MicrobitWebUSBConnection (WebUSB supported)", () => {
   it("connects and disconnects updating status and events", async () => {
     const events: ConnectionStatus[] = [];
     const connection = new MicrobitWebUSBConnection();
-    connection.on(EVENT_STATUS, (status: ConnectionStatus) =>
-      events.push(status)
-    );
+    connection.addEventListener(EVENT_STATUS, (event: StatusEvent) => {
+      events.push(event.status);
+    });
 
     await connection.connect();
 

--- a/src/device/webusb.test.ts
+++ b/src/device/webusb.test.ts
@@ -9,7 +9,7 @@
  * It might be we could create a custom environment that was web but
  * with a tweak to Buffer.
  */
-import { ConnectionStatus, EVENT_STATUS, StatusEvent } from "./device";
+import { ConnectionStatus, ConnectionStatusEvent } from "./device";
 import { NullLogging } from "../deployment/default/logging";
 import { MicrobitWebUSBConnection } from "./webusb";
 import { vi } from "vitest";
@@ -59,7 +59,7 @@ describeDeviceOnly("MicrobitWebUSBConnection (WebUSB supported)", () => {
   it("connects and disconnects updating status and events", async () => {
     const events: ConnectionStatus[] = [];
     const connection = new MicrobitWebUSBConnection();
-    connection.addEventListener(EVENT_STATUS, (event: StatusEvent) => {
+    connection.addEventListener("status", (event: ConnectionStatusEvent) => {
       events.push(event.status);
     });
 

--- a/src/device/webusb.ts
+++ b/src/device/webusb.ts
@@ -23,7 +23,7 @@ import {
   SerialErrorEvent,
   SerialResetEvent,
   StartUSBSelect,
-  StatusEvent,
+  ConnectionStatusEvent,
   WebUSBError,
 } from "./device";
 import { TypedEventTarget } from "../common/events";
@@ -318,7 +318,7 @@ export class MicrobitWebUSBConnection
     this.status = newStatus;
     this.visibilityReconnect = false;
     this.log("Device status " + newStatus);
-    this.dispatchTypedEvent("status", new StatusEvent(newStatus));
+    this.dispatchTypedEvent("status", new ConnectionStatusEvent(newStatus));
   }
 
   private async withEnrichedErrors<T>(f: () => Promise<T>): Promise<T> {
@@ -406,7 +406,7 @@ export class MicrobitWebUSBConnection
     this.device = await navigator.usb.requestDevice({
       filters: [{ vendorId: 0x0d28, productId: 0x0204 }],
     });
-    this.dispatchTypedEvent("start_usb_select", new EndUSBSelect());
+    this.dispatchTypedEvent("end_usb_select", new EndUSBSelect());
     return this.device;
   }
 }

--- a/src/device/webusb.ts
+++ b/src/device/webusb.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import EventEmitter from "events";
 import { Logging } from "../logging/logging";
 import { NullLogging } from "../deployment/default/logging";
 import { withTimeout, TimeoutError } from "./async-util";
@@ -14,18 +13,20 @@ import {
   ConnectionStatus,
   ConnectOptions,
   DeviceConnection,
-  EVENT_END_USB_SELECT,
-  EVENT_FLASH,
-  EVENT_SERIAL_DATA,
-  EVENT_SERIAL_ERROR,
-  EVENT_SERIAL_RESET,
-  EVENT_START_USB_SELECT,
-  EVENT_STATUS,
+  DeviceConnectionEventMap,
+  EndUSBSelect,
   FlashDataSource,
+  FlashEvent,
   HexGenerationError,
   MicrobitWebUSBConnectionOptions,
+  SerialDataEvent,
+  SerialErrorEvent,
+  SerialResetEvent,
+  StartUSBSelect,
+  StatusEvent,
   WebUSBError,
 } from "./device";
+import { TypedEventTarget } from "../common/events";
 
 // Temporary workaround for ChromeOS 105 bug.
 // See https://bugs.chromium.org/p/chromium/issues/detail?id=1363712&q=usb&can=2
@@ -38,7 +39,7 @@ export const isChromeOS105 = (): boolean => {
  * A WebUSB connection to a micro:bit device.
  */
 export class MicrobitWebUSBConnection
-  extends EventEmitter
+  extends TypedEventTarget<DeviceConnectionEventMap>
   implements DeviceConnection
 {
   status: ConnectionStatus =
@@ -63,7 +64,7 @@ export class MicrobitWebUSBConnection
   private serialReadInProgress: Promise<void> | undefined;
 
   private serialListener = (data: string) => {
-    this.emit(EVENT_SERIAL_DATA, data);
+    this.dispatchTypedEvent("serial_data", new SerialDataEvent(data));
   };
 
   private flashing: boolean = false;
@@ -151,7 +152,6 @@ export class MicrobitWebUSBConnection
   }
 
   dispose() {
-    this.removeAllListeners();
     if (navigator.usb) {
       navigator.usb.removeEventListener("disconnect", this.handleDisconnect);
     }
@@ -200,7 +200,7 @@ export class MicrobitWebUSBConnection
       await this.withEnrichedErrors(() =>
         this.flashInternal(dataSource, options)
       );
-      this.emit(EVENT_FLASH);
+      this.dispatchTypedEvent("flash", new FlashEvent());
 
       const flashTime = new Date().getTime() - startTime;
       this.logging.event({
@@ -278,7 +278,7 @@ export class MicrobitWebUSBConnection
       .startSerial(this.serialListener)
       .then(() => this.log("Finished listening for serial data"))
       .catch((e) => {
-        this.emit(EVENT_SERIAL_ERROR, e);
+        this.dispatchTypedEvent("serial_error", new SerialErrorEvent(e));
       });
   }
 
@@ -287,7 +287,7 @@ export class MicrobitWebUSBConnection
       this.connection.stopSerial(this.serialListener);
       await this.serialReadInProgress;
       this.serialReadInProgress = undefined;
-      this.emit(EVENT_SERIAL_RESET, {});
+      this.dispatchTypedEvent("serial_reset", new SerialResetEvent());
     }
   }
 
@@ -318,7 +318,7 @@ export class MicrobitWebUSBConnection
     this.status = newStatus;
     this.visibilityReconnect = false;
     this.log("Device status " + newStatus);
-    this.emit(EVENT_STATUS, this.status);
+    this.dispatchTypedEvent("status", new StatusEvent(newStatus));
   }
 
   private async withEnrichedErrors<T>(f: () => Promise<T>): Promise<T> {
@@ -402,11 +402,11 @@ export class MicrobitWebUSBConnection
     if (this.device) {
       return this.device;
     }
-    this.emit(EVENT_START_USB_SELECT);
+    this.dispatchTypedEvent("start_usb_select", new StartUSBSelect());
     this.device = await navigator.usb.requestDevice({
       filters: [{ vendorId: 0x0d28, productId: 0x0204 }],
     });
-    this.emit(EVENT_END_USB_SELECT);
+    this.dispatchTypedEvent("start_usb_select", new EndUSBSelect());
     return this.device;
   }
 }

--- a/src/e2e/simulator.test.ts
+++ b/src/e2e/simulator.test.ts
@@ -5,16 +5,23 @@
  */
 import { test } from "./app-test-fixtures.js";
 
-const basicTest = "from microbit import *\ndisplay.show(Image.NO)";
+const basicTest = `from microbit import *
+display.show(Image.NO)`;
 
-const buttonTest =
-  "from microbit import *\nwhile True:\nif button_a.was_pressed():\ndisplay.show(Image.NO)";
+const buttonTest = `from microbit import *
+while True:
+    if button_a.was_pressed():
+        display.show(Image.NO)`;
 
-const gestureTest =
-  "from microbit import *\nwhile True:\nif accelerometer.was_gesture('freefall'):\ndisplay.show(Image.NO)";
+const gestureTest = `from microbit import *
+while True:
+    if accelerometer.was_gesture('freefall'):
+        display.show(Image.NO)`;
 
-const sliderTest =
-  "from microbit import *\nwhile True:\nif temperature() == -5:\ndisplay.show(Image.NO)";
+const sliderTest = `from microbit import *
+while True:
+    if temperature() == -5:
+        display.show(Image.NO)`;
 
 test.describe("simulator", () => {
   test("responds to a sent gesture", async ({ app }) => {

--- a/src/editor/codemirror/language-server/view.ts
+++ b/src/editor/codemirror/language-server/view.ts
@@ -6,9 +6,11 @@
 import type { PluginValue, ViewUpdate } from "@codemirror/view";
 import { EditorView, ViewPlugin } from "@codemirror/view";
 import { IntlShape } from "react-intl";
-import * as LSP from "vscode-languageserver-protocol";
 import { ApiReferenceMap } from "../../../documentation/mapping/content";
-import { LanguageServerClient } from "../../../language-server/client";
+import {
+  DiagnosticsEvent,
+  LanguageServerClient,
+} from "../../../language-server/client";
 import { Logging } from "../../../logging/logging";
 import { Action, setDiagnostics } from "../lint/lint";
 import { autocompletion } from "./autocompletion";
@@ -23,7 +25,8 @@ import { DeviceConnection, EVENT_STATUS } from "../../../device/device";
  * the language server when the document changes.
  */
 class LanguageServerView extends BaseLanguageServerView implements PluginValue {
-  private diagnosticsListener = (params: LSP.PublishDiagnosticsParams) => {
+  private diagnosticsListener = (event: DiagnosticsEvent) => {
+    const params = event.detail;
     if (params.uri === this.uri) {
       const diagnostics = diagnosticsMapping(
         this.view.state.doc,
@@ -64,8 +67,8 @@ class LanguageServerView extends BaseLanguageServerView implements PluginValue {
   ) {
     super(view);
 
-    this.client.on("diagnostics", this.diagnosticsListener);
-    this.device.on(EVENT_STATUS, this.onDeviceStatusChanged);
+    this.client.addEventListener("diagnostics", this.diagnosticsListener);
+    this.device.addEventListener(EVENT_STATUS, this.onDeviceStatusChanged);
 
     // Is there a better way to do this? We can 't dispatch at this point.
     // It would be best to do this with initial state and avoid the dispatch.
@@ -95,8 +98,8 @@ class LanguageServerView extends BaseLanguageServerView implements PluginValue {
 
   destroy() {
     this.destroyed = true;
-    this.client.removeListener("diagnostics", this.diagnosticsListener);
-    this.device.removeListener(EVENT_STATUS, this.onDeviceStatusChanged);
+    this.client.removeEventListener("diagnostics", this.diagnosticsListener);
+    this.device.removeEventListener(EVENT_STATUS, this.onDeviceStatusChanged);
     // We don't own the client/connection which might outlive us, just our notifications.
   }
 }

--- a/src/editor/codemirror/language-server/view.ts
+++ b/src/editor/codemirror/language-server/view.ts
@@ -17,7 +17,7 @@ import { autocompletion } from "./autocompletion";
 import { BaseLanguageServerView, clientFacet, uriFacet } from "./common";
 import { diagnosticsMapping } from "./diagnostics";
 import { signatureHelp } from "./signatureHelp";
-import { DeviceConnection, EVENT_STATUS } from "../../../device/device";
+import { DeviceConnection } from "../../../device/device";
 
 /**
  * The main extension. This synchronises the diagnostics between the client
@@ -68,7 +68,7 @@ class LanguageServerView extends BaseLanguageServerView implements PluginValue {
     super(view);
 
     this.client.addEventListener("diagnostics", this.diagnosticsListener);
-    this.device.addEventListener(EVENT_STATUS, this.onDeviceStatusChanged);
+    this.device.addEventListener("status", this.onDeviceStatusChanged);
 
     // Is there a better way to do this? We can 't dispatch at this point.
     // It would be best to do this with initial state and avoid the dispatch.
@@ -99,7 +99,7 @@ class LanguageServerView extends BaseLanguageServerView implements PluginValue {
   destroy() {
     this.destroyed = true;
     this.client.removeEventListener("diagnostics", this.diagnosticsListener);
-    this.device.removeEventListener(EVENT_STATUS, this.onDeviceStatusChanged);
+    this.device.removeEventListener("status", this.onDeviceStatusChanged);
     // We don't own the client/connection which might outlive us, just our notifications.
   }
 }

--- a/src/fs/fs.test.ts
+++ b/src/fs/fs.test.ts
@@ -12,7 +12,6 @@ import { NullLogging } from "../deployment/default/logging";
 import { BoardId } from "../device/board-id";
 import {
   diff,
-  EVENT_PROJECT_UPDATED,
   FileSystem,
   MAIN_FILE,
   Project,
@@ -55,7 +54,9 @@ describe("Filesystem", () => {
   beforeEach(() => {
     events = [];
     ufs = new FileSystem(logging, host, fsMicroPythonSource);
-    ufs.addListener(EVENT_PROJECT_UPDATED, events.push.bind(events));
+    ufs.addEventListener("project_updated", (e) => {
+      events.push(e.project);
+    });
   });
 
   it("has an initial blank project", async () => {

--- a/src/fs/host-iframe.test.ts
+++ b/src/fs/host-iframe.test.ts
@@ -14,7 +14,7 @@ describe("IframeHost", () => {
   const fs = {
     read: () => new TextEncoder().encode("Code read!"),
     write: mockWrite,
-    addListener: mockAddListener,
+    addEventListener: mockAddListener,
     getPythonProject: () => "",
   } as any;
 

--- a/src/fs/host.ts
+++ b/src/fs/host.ts
@@ -4,13 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 import debounce from "lodash.debounce";
-import {
-  FileSystem,
-  VersionAction,
-  EVENT_PROJECT_UPDATED,
-  EVENT_TEXT_EDIT,
-  MAIN_FILE,
-} from "./fs";
+import { FileSystem, VersionAction, MAIN_FILE } from "./fs";
 import { Logging } from "../logging/logging";
 import {
   defaultInitialProject,
@@ -135,8 +129,8 @@ export class IframeHost implements Host {
     const debounceCodeChange = debounce(() => {
       notifyWorkspaceSave(fs, this.parent);
     }, this.debounceDelay);
-    fs.addListener(EVENT_PROJECT_UPDATED, debounceCodeChange);
-    fs.addListener(EVENT_TEXT_EDIT, debounceCodeChange);
+    fs.addEventListener("project_updated", debounceCodeChange);
+    fs.addEventListener("file_text_updated", debounceCodeChange);
 
     this.window.addEventListener("message", (event) => {
       if (event?.data.type === messages.type) {

--- a/src/project/project-actions.tsx
+++ b/src/project/project-actions.tsx
@@ -22,7 +22,7 @@ import {
   ConnectionStatus,
   ConnectOptions,
   DeviceConnection,
-  EVENT_END_USB_SELECT,
+  EndUSBSelect as RequestDeviceEndEvent,
   HexGenerationError,
   WebUSBError,
   WebUSBErrorCode,
@@ -830,7 +830,10 @@ export class ProjectActions {
     finalFocusRef: FinalFocusRef
   ) {
     if (e instanceof WebUSBError) {
-      this.device.emit(EVENT_END_USB_SELECT);
+      this.device.dispatchTypedEvent(
+        "end_usb_select",
+        new RequestDeviceEndEvent()
+      );
       switch (e.code) {
         case "no-device-selected": {
           // User just cancelled the browser dialog, perhaps because there

--- a/src/project/project-hooks.tsx
+++ b/src/project/project-hooks.tsx
@@ -9,7 +9,7 @@ import useActionFeedback from "../common/use-action-feedback";
 import { useDialogs } from "../common/use-dialogs";
 import useIsUnmounted from "../common/use-is-unmounted";
 import { useDevice } from "../device/device-hooks";
-import { EVENT_PROJECT_UPDATED, Project, VersionAction } from "../fs/fs";
+import { Project, VersionAction } from "../fs/fs";
 import { useFileSystem } from "../fs/fs-hooks";
 import {
   extractModuleData,
@@ -92,9 +92,9 @@ export const useProject = (): DefaultedProject => {
         setState(defaultedProject(fs, intl));
       }
     };
-    fs.on(EVENT_PROJECT_UPDATED, listener);
+    fs.addEventListener("project_updated", listener);
     return () => {
-      fs.removeListener(EVENT_PROJECT_UPDATED, listener);
+      fs.removeEventListener("project_updated", listener);
     };
   }, [fs, isUnmounted, intl]);
   return state;

--- a/src/serial/XTerm.tsx
+++ b/src/serial/XTerm.tsx
@@ -12,7 +12,11 @@ import "xterm/css/xterm.css";
 import useActionFeedback from "../common/use-action-feedback";
 import useIsUnmounted from "../common/use-is-unmounted";
 import { backgroundColorTerm } from "../deployment/misc";
-import { EVENT_SERIAL_DATA, EVENT_SERIAL_RESET } from "../device/device";
+import {
+  EVENT_SERIAL_DATA,
+  EVENT_SERIAL_RESET,
+  SerialDataEvent,
+} from "../device/device";
 import { parseTraceLine, useDevice } from "../device/device-hooks";
 import { useSelection } from "../workbench/use-selection";
 import { WebLinkProvider } from "./link-provider";
@@ -96,9 +100,9 @@ const useManagedTermimal = (
       customKeyEventHandler(e, tabOutRef)
     );
 
-    const serialListener = (data: string) => {
+    const serialListener = (event: SerialDataEvent) => {
       if (!isUnmounted()) {
-        terminal.write(data);
+        terminal.write(event.data);
       }
     };
     const resetListener = () => {
@@ -106,8 +110,8 @@ const useManagedTermimal = (
         terminal.reset();
       }
     };
-    device.on(EVENT_SERIAL_DATA, serialListener);
-    device.on(EVENT_SERIAL_RESET, resetListener);
+    device.addEventListener(EVENT_SERIAL_DATA, serialListener);
+    device.addEventListener(EVENT_SERIAL_RESET, resetListener);
     terminal.onData((data: string) => {
       if (!isUnmounted()) {
         // Async for internal error handling, we don't need to wait.
@@ -177,8 +181,8 @@ const useManagedTermimal = (
 
     return () => {
       currentTerminalRef.current = undefined;
-      device.removeListener(EVENT_SERIAL_RESET, resetListener);
-      device.removeListener(EVENT_SERIAL_DATA, serialListener);
+      device.removeEventListener(EVENT_SERIAL_RESET, resetListener);
+      device.removeEventListener(EVENT_SERIAL_DATA, serialListener);
       resizeObserver.disconnect();
       terminal.dispose();
     };

--- a/src/serial/XTerm.tsx
+++ b/src/serial/XTerm.tsx
@@ -12,11 +12,7 @@ import "xterm/css/xterm.css";
 import useActionFeedback from "../common/use-action-feedback";
 import useIsUnmounted from "../common/use-is-unmounted";
 import { backgroundColorTerm } from "../deployment/misc";
-import {
-  EVENT_SERIAL_DATA,
-  EVENT_SERIAL_RESET,
-  SerialDataEvent,
-} from "../device/device";
+import { SerialDataEvent } from "../device/device";
 import { parseTraceLine, useDevice } from "../device/device-hooks";
 import { useSelection } from "../workbench/use-selection";
 import { WebLinkProvider } from "./link-provider";
@@ -110,8 +106,8 @@ const useManagedTermimal = (
         terminal.reset();
       }
     };
-    device.addEventListener(EVENT_SERIAL_DATA, serialListener);
-    device.addEventListener(EVENT_SERIAL_RESET, resetListener);
+    device.addEventListener("serial_data", serialListener);
+    device.addEventListener("serial_reset", resetListener);
     terminal.onData((data: string) => {
       if (!isUnmounted()) {
         // Async for internal error handling, we don't need to wait.
@@ -181,8 +177,8 @@ const useManagedTermimal = (
 
     return () => {
       currentTerminalRef.current = undefined;
-      device.removeEventListener(EVENT_SERIAL_RESET, resetListener);
-      device.removeEventListener(EVENT_SERIAL_DATA, serialListener);
+      device.removeEventListener("serial_reset", resetListener);
+      device.removeEventListener("serial_data", serialListener);
       resizeObserver.disconnect();
       terminal.dispose();
     };

--- a/src/simulator/SimulatorActionBar.tsx
+++ b/src/simulator/SimulatorActionBar.tsx
@@ -17,7 +17,6 @@ import {
   useSimulator,
   useSyncStatus,
 } from "../device/device-hooks";
-import { EVENT_REQUEST_FLASH } from "../device/simulator";
 import { useFileSystem } from "../fs/fs-hooks";
 import { useLogging } from "../logging/logging-hooks";
 import { RunningStatus } from "./Simulator";
@@ -71,9 +70,9 @@ const SimulatorActionBar = ({
     setIsMuted(!isMuted);
   }, [device, isMuted, setIsMuted]);
   useEffect(() => {
-    device.on(EVENT_REQUEST_FLASH, handlePlay);
+    device.addEventListener("request_flash", handlePlay);
     return () => {
-      device.removeListener(EVENT_REQUEST_FLASH, handlePlay);
+      device.removeEventListener("request_flash", handlePlay);
     };
   }, [device, handlePlay]);
   const size = "md";

--- a/src/simulator/SimulatorModules.tsx
+++ b/src/simulator/SimulatorModules.tsx
@@ -20,10 +20,10 @@ import { useIntl } from "react-intl";
 import ExpandCollapseIcon from "../common/ExpandCollapseIcon";
 import useRafState from "../common/use-raf-state";
 import {
-  EVENT_STATE_CHANGE,
   RangeSensor as RangeSensorType,
   SensorStateKey,
   SimulatorState,
+  StateChangeEvent,
 } from "../device/simulator";
 import { useRouterState } from "../router-hooks";
 import ButtonsModule from "./ButtonsModule";
@@ -110,9 +110,12 @@ const SimulatorModules = ({ running, ...props }: SimulatorModulesProps) => {
   );
   const intl = useIntl();
   useEffect(() => {
-    device.on(EVENT_STATE_CHANGE, setState);
+    const listener = (event: StateChangeEvent) => {
+      setState(event.state);
+    };
+    device.addEventListener("state_change", listener);
     return () => {
-      device.removeListener(EVENT_STATE_CHANGE, setState);
+      device.removeEventListener("state_change", listener);
     };
   }, [device, setState]);
   const handleSensorChange = useCallback(

--- a/src/simulator/data-logging-hooks.tsx
+++ b/src/simulator/data-logging-hooks.tsx
@@ -1,15 +1,18 @@
 import React, { ReactNode, useContext, useEffect } from "react";
 import useRafState from "../common/use-raf-state";
 import { useSimulator } from "../device/device-hooks";
-import { DataLog, EVENT_LOG_DATA } from "../device/simulator";
+import { DataLog, LogDataEvent } from "../device/simulator";
 
 const useDataLogInternal = (): DataLog => {
   const simulator = useSimulator();
   const [value, setValue] = useRafState<DataLog>(simulator.log);
   useEffect(() => {
-    simulator.on(EVENT_LOG_DATA, setValue);
+    const listener = (event: LogDataEvent) => {
+      setValue(event.log);
+    };
+    simulator.addEventListener("log_data", listener);
     return () => {
-      simulator.removeListener(EVENT_LOG_DATA, setValue);
+      simulator.removeEventListener("log_data", listener);
     };
   }, [simulator, setValue]);
   return value;

--- a/src/simulator/radio-hooks.tsx
+++ b/src/simulator/radio-hooks.tsx
@@ -7,7 +7,7 @@ import React, {
   useState,
 } from "react";
 import { useSimulator } from "../device/device-hooks";
-import { EVENT_RADIO_DATA, EVENT_RADIO_RESET } from "../device/simulator";
+import { RadioDataEvent } from "../device/simulator";
 
 const messageLimit = 100;
 let idSeq = 0;
@@ -52,7 +52,8 @@ const useRadioChatItemsInternal = (
   }, [group, prevGroup]);
 
   useEffect(() => {
-    const handleReceive = (message: string) => {
+    const handleReceive = (event: RadioDataEvent) => {
+      const message = event.text;
       setItems((items) =>
         cappedMessages([
           ...items,
@@ -63,11 +64,11 @@ const useRadioChatItemsInternal = (
     const handleReset = () => {
       setItems([{ type: "groupChange", group, id: idSeq++ }]);
     };
-    device.on(EVENT_RADIO_DATA, handleReceive);
-    device.on(EVENT_RADIO_RESET, handleReset);
+    device.addEventListener("radio_data", handleReceive);
+    device.addEventListener("radio_reset", handleReset);
     return () => {
-      device.removeListener(EVENT_RADIO_RESET, handleReset);
-      device.removeListener(EVENT_RADIO_DATA, handleReceive);
+      device.removeEventListener("radio_reset", handleReset);
+      device.removeEventListener("radio_data", handleReceive);
     };
   }, [device, group]);
   const handleSend = useCallback(

--- a/src/workbench/connect-dialogs/Overlay.tsx
+++ b/src/workbench/connect-dialogs/Overlay.tsx
@@ -6,10 +6,6 @@
 import { Box, useDisclosure } from "@chakra-ui/react";
 import { useCallback, useEffect } from "react";
 import { zIndexOverlay } from "../../common/zIndex";
-import {
-  EVENT_END_USB_SELECT,
-  EVENT_START_USB_SELECT,
-} from "../../device/device";
 import { useDevice } from "../../device/device-hooks";
 
 const Overlay = () => {
@@ -22,11 +18,11 @@ const Overlay = () => {
     selectingDevice.onClose();
   }, [selectingDevice]);
   useEffect(() => {
-    device.addEventListener(EVENT_START_USB_SELECT, showOverlay);
-    device.addEventListener(EVENT_END_USB_SELECT, hideOverlay);
+    device.addEventListener("start_usb_select", showOverlay);
+    device.addEventListener("end_usb_select", hideOverlay);
     return () => {
-      device.removeEventListener(EVENT_START_USB_SELECT, showOverlay);
-      device.removeEventListener(EVENT_END_USB_SELECT, hideOverlay);
+      device.removeEventListener("start_usb_select", showOverlay);
+      device.removeEventListener("end_usb_select", hideOverlay);
     };
   }, [device, showOverlay, hideOverlay]);
   return (

--- a/src/workbench/connect-dialogs/Overlay.tsx
+++ b/src/workbench/connect-dialogs/Overlay.tsx
@@ -22,11 +22,11 @@ const Overlay = () => {
     selectingDevice.onClose();
   }, [selectingDevice]);
   useEffect(() => {
-    device.on(EVENT_START_USB_SELECT, showOverlay);
-    device.on(EVENT_END_USB_SELECT, hideOverlay);
+    device.addEventListener(EVENT_START_USB_SELECT, showOverlay);
+    device.addEventListener(EVENT_END_USB_SELECT, hideOverlay);
     return () => {
-      device.removeListener(EVENT_START_USB_SELECT, showOverlay);
-      device.removeListener(EVENT_END_USB_SELECT, hideOverlay);
+      device.removeEventListener(EVENT_START_USB_SELECT, showOverlay);
+      device.removeEventListener(EVENT_END_USB_SELECT, hideOverlay);
     };
   }, [device, showOverlay, hideOverlay]);
   return (


### PR DESCRIPTION
This should amount no meaningful change but is a useful preliminary to extracting the device code for reuse.

Incorporates the only meaningful file from https://github.com/DerZade/typescript-event-target/ (with licence details) to save on the dependency.