### PR TITLE
Reinstate simulator compass animation

### DIFF
--- a/src/simulator/CompassModule.tsx
+++ b/src/simulator/CompassModule.tsx
@@ -65,12 +65,9 @@ const CompassModule = ({
               onSensorChange={onValueChange}
               minimised={minimised}
             />
-            <Icon
-              ref={ref}
-              as={CompassHeadingIcon}
-              color="blimpTeal.400"
-              boxSize="20"
-            />
+            <Icon ref={ref} color="blimpTeal.400" boxSize="20">
+              <CompassHeadingIcon />
+            </Icon>
           </HStack>
           <Stack spacing={5} mt={5}>
             <Text as="h4" fontSize="sm">


### PR DESCRIPTION
This must have regressed when we updated Chakra?

The following warning is logged when using the `as` prop, and is fixed by pass the icon as a child instead.
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()