### PR TITLE
Fix escape crowdin jipt url

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
     <script type="text/javascript" id="crowdin-jipt-config">
       (function () {
         function escape() {
-          window.location.href = "%VITE_FULL_URL";
+          window.location.href = "%VITE_FULL_URL%";
         }
         window._jipt = [
           ["project", "microbitorg"],


### PR DESCRIPTION
Redirect to a valid URL when deciding not to log into crowdin.

**Issue:** 

1. Visit https://python.microbit.org/v/3?flag=translate
2. Click on the close button instead of logging into Crowdin.
3. Get redirected to `https://python.microbit.org/v/%VITE_FULL_URL`, which is a request error 

