### PR TITLE
afterrequestdevice is now dispatched in error cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@codemirror/view": "^6.26.3",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
-        "@microbit/microbit-connection": "^0.0.0-alpha.36",
+        "@microbit/microbit-connection": "^0.0.0-alpha.38",
         "@microbit/microbit-fs": "^0.10.0",
         "@sanity/block-content-to-react": "^3.0.0",
         "@sanity/image-url": "^1.0.1",
@@ -3795,9 +3795,9 @@
       }
     },
     "node_modules/@microbit/microbit-connection": {
-      "version": "0.0.0-alpha.36",
-      "resolved": "https://registry.npmjs.org/@microbit/microbit-connection/-/microbit-connection-0.0.0-alpha.36.tgz",
-      "integrity": "sha512-R/UQmPQq1s9eSx1NFWPfsJAsflJVbMCyfuHAuqEri3eCSRy5cJ8qqRmdlMQ40XfTps3roDMJkVUGN5Zw6JUCAg==",
+      "version": "0.0.0-alpha.38",
+      "resolved": "https://registry.npmjs.org/@microbit/microbit-connection/-/microbit-connection-0.0.0-alpha.38.tgz",
+      "integrity": "sha512-okWERlTyezY8m9WdlhLCVIIXtJh8Brrv239JPxD0BPIlw84ZWEAB0X7LPQS5CPBpfeFm13b3y5OHR5HR6ePRlw==",
       "dependencies": {
         "@microbit/microbit-universal-hex": "^0.2.2",
         "@types/web-bluetooth": "^0.0.20",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@codemirror/view": "^6.26.3",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
-    "@microbit/microbit-connection": "^0.0.0-alpha.36",
+    "@microbit/microbit-connection": "^0.0.0-alpha.38",
     "@microbit/microbit-fs": "^0.10.0",
     "@sanity/block-content-to-react": "^3.0.0",
     "@sanity/image-url": "^1.0.1",

--- a/src/project/project-actions.tsx
+++ b/src/project/project-actions.tsx
@@ -20,7 +20,6 @@ import { Dialogs } from "../common/use-dialogs";
 import {
   ConnectionStatus,
   MicrobitWebUSBConnection,
-  AfterRequestDevice,
   FlashDataError,
   DeviceError,
   DeviceErrorCode,
@@ -836,10 +835,6 @@ export class ProjectActions {
     finalFocusRef: FinalFocusRef
   ) {
     if (e instanceof DeviceError) {
-      this.device.dispatchTypedEvent(
-        "afterrequestdevice",
-        new AfterRequestDevice()
-      );
       switch (e.code) {
         case "no-device-selected": {
           // User just cancelled the browser dialog, perhaps because there


### PR DESCRIPTION
Since https://github.com/microbit-foundation/microbit-connection/pull/63

Remove workaround in the error handler.

Draft for me to test deployment.