### PR TITLE
Don't check board version if device is not connected

### DIFF
--- a/src/editor/codemirror/language-server/diagnostics.ts
+++ b/src/editor/codemirror/language-server/diagnostics.ts
@@ -8,6 +8,7 @@ import * as LSP from "vscode-languageserver-protocol";
 import { Action, Diagnostic } from "../lint/lint";
 import { positionToOffset } from "./positions";
 import { MicrobitUSBConnection } from "@microbit/microbit-connection/usb";
+import { ConnectionStatus } from "@microbit/microbit-connection";
 
 const reportMicrobitVersionApiUnsupported =
   "reportMicrobitVersionApiUnsupported";
@@ -32,7 +33,9 @@ export const diagnosticsMapping = (
       // and warnOnV2OnlyFeatures setting is on.
       if (
         code === reportMicrobitVersionApiUnsupported &&
-        (!warnOnV2OnlyFeatures || device.getBoardVersion() !== "V1")
+        (!warnOnV2OnlyFeatures ||
+          device.status !== ConnectionStatus.Connected ||
+          device.getBoardVersion() !== "V1")
       ) {
         return undefined;
       }


### PR DESCRIPTION
Since upgrading the connection library, getBoardVersion throws "Not connected" error if micro:bit is not connected. In this case, we only want to check the board version to warn users of v2-only features when a micro:bit is connected.

To repro issue, open https://python.microbit.org/v/beta, then drag and drop v2-only code snippet, such as a data logging code snippet. See error thrown in devtools console.