### PR TITLE
Upgrade to @microbit/ui@0.1.0-alpha.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@codemirror/view": "^6.26.3",
         "@microbit/microbit-connection": "^1.0.0",
         "@microbit/microbit-fs": "^0.10.0",
-        "@microbit/ui": "0.1.0-alpha.21",
+        "@microbit/ui": "0.1.0-alpha.22",
         "@sanity/block-content-to-react": "^3.0.0",
         "@sanity/image-url": "^1.0.1",
         "@testing-library/jest-dom": "^5.14.1",
@@ -3266,9 +3266,9 @@
       }
     },
     "node_modules/@microbit/ui": {
-      "version": "0.1.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@microbit/ui/-/ui-0.1.0-alpha.21.tgz",
-      "integrity": "sha512-KIcT2xMyxdbcEl6izWRUwF4N95oDwhNmHUMOmjKoskpGemLsvo59/SWioSWMAhHOtwVcrTg/MYvXBxD612+1cg==",
+      "version": "0.1.0-alpha.22",
+      "resolved": "https://registry.npmjs.org/@microbit/ui/-/ui-0.1.0-alpha.22.tgz",
+      "integrity": "sha512-bJAW+/ic9LpwuiDnVPs/elJssHgqpG/bUFn9H9fM1vu5GzKQDf1hx7UDThDzhH61g1CvXklI1wOe2IjMwG9Tjg==",
       "license": "MIT",
       "peerDependencies": {
         "@pandacss/dev": "^1.11.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@codemirror/view": "^6.26.3",
     "@microbit/microbit-connection": "^1.0.0",
     "@microbit/microbit-fs": "^0.10.0",
-    "@microbit/ui": "0.1.0-alpha.21",
+    "@microbit/ui": "0.1.0-alpha.22",
     "@sanity/block-content-to-react": "^3.0.0",
     "@sanity/image-url": "^1.0.1",
     "@testing-library/jest-dom": "^5.14.1",

--- a/src/project/ProjectNameEditable.tsx
+++ b/src/project/ProjectNameEditable.tsx
@@ -41,6 +41,9 @@ const ProjectNameEditable = ({
       label={intl.formatMessage({ id: "edit-name-project-hover" })}
       placement="top start"
       key="button"
+      // The button is a pencil and nothing else, so the tooltip is its only
+      // visible explanation: no warmup.
+      delay={0}
     >
       <IconButton
         size="md"


### PR DESCRIPTION
Tooltips now wait ~1.5s before their first appearance, react-aria's warmup, which the library had been overriding to 0 for Chakra parity. The wait is per bout of interest rather than per control — a global warm flag opens every tooltip after the first instantly — so the toolbar no longer fires a tooltip at a pointer merely crossing New, Send, Save and Reset, and the drag hints on code blocks and API signatures stay out of the way while reading.

ProjectNameEditable opts out with delay={0}: its trigger is a pencil and nothing else, so the tooltip is the only visible explanation and a wait reads as broken. That is the rule for the whole family — pass 0 where the tooltip is the label, leave the default where the control already says what it is.

Tooltips also linger ~500ms after mouse-out rather than closing instantly, which is what lets the pointer move onto one to read it (WCAG 1.4.13).