### PR TITLE
Reinstate box shadow for HideSplitViewButton

### DIFF
--- a/src/common/SplitView/HideSplitViewButton.tsx
+++ b/src/common/SplitView/HideSplitViewButton.tsx
@@ -82,6 +82,9 @@ const HideSplitViewButton = React.forwardRef(
             // ghost-over-gray values).
             _hover: { background: "gray.100" },
             _active: { background: "gray.200" },
+            // Likewise a flat boxShadow from a call site (e.g. Simulator's
+            // md shadow) beats the recipe-layer focus ring — restate it.
+            _focusVisible: { focusShadow: "outline" },
             color: "brand.500",
             zIndex: "splitViewHideButton",
             ...cssProp,

--- a/src/simulator/Simulator.tsx
+++ b/src/simulator/Simulator.tsx
@@ -110,6 +110,7 @@ const Simulator = ({
             onClick={onSimulatorHide}
             splitViewShown={shown}
             direction="expandLeft"
+            css={{ boxShadow: "md" }}
           />
         </Flex>
         <VStack gap="5" bg="gray.75" ref={simControlsRef}>


### PR DESCRIPTION
Maintain focusVisible styling as an override.

The box-shadow was removed in favour of focus-visible in https://github.com/microbit-foundation/python-editor-v3/commit/87f958d1495706da3950f044287c4f31ca81c1a3, but both can work together.

Closes #1250 