### PR TITLE
RAC: swap custom outline variant for ui library secondary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: npm install --no-save @microbit-foundation/python-editor-v3-microbit@0.2.0-experiment.rai.66 @microbit-foundation/website-deploy-aws@0.6.0 @microbit-foundation/website-deploy-aws-config@0.9.0 @microbit-foundation/circleci-npm-package-versioner@1
+      - run: npm install --no-save @microbit-foundation/python-editor-v3-microbit@0.2.0-experiment.rai.67 @microbit-foundation/website-deploy-aws@0.6.0 @microbit-foundation/website-deploy-aws-config@0.9.0 @microbit-foundation/circleci-npm-package-versioner@1
         if: github.repository_owner == 'microbit-foundation'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/deployment/default/panda-preset.ts
+++ b/src/deployment/default/panda-preset.ts
@@ -109,13 +109,6 @@ export const appPreset = definePreset({
         button: {
           variants: {
             variant: {
-              outline: {
-                borderWidth: "2px",
-                borderColor: "currentColor",
-                color: "brand.500",
-                bg: "transparent",
-                _hover: { color: "brand.600", bg: "transparent" },
-              },
               // Icon buttons on the app's dark chrome (sidebar header,
               // serial bar): white glyph, white pill on hover. The Chakra
               // variant was ghost-based with callers passing color="white";
@@ -143,7 +136,6 @@ export const appPreset = definePreset({
               },
             },
           },
-          defaultVariants: { variant: "outline" },
         },
       },
     },

--- a/src/simulator/SimulatorActionBar.tsx
+++ b/src/simulator/SimulatorActionBar.tsx
@@ -92,7 +92,7 @@ const SimulatorActionBar = ({
     >
       <IconButton
         size={size}
-        variant="outline"
+        variant="secondary"
         onPress={() => handleStop("user")}
         aria-label={intl.formatMessage({ id: "simulator-stop" })}
         isDisabled={running === RunningStatus.STOPPED}
@@ -101,7 +101,7 @@ const SimulatorActionBar = ({
       </IconButton>
       <IconButton
         size={size}
-        variant="outline"
+        variant="secondary"
         onPress={device.reset}
         aria-label={intl.formatMessage({ id: "simulator-reset" })}
         isDisabled={running === RunningStatus.STOPPED}
@@ -110,7 +110,7 @@ const SimulatorActionBar = ({
       </IconButton>
       <IconButton
         size={size}
-        variant="outline"
+        variant="secondary"
         onPress={handleMuteUnmute}
         aria-label={
           isMuted


### PR DESCRIPTION
Main visual impact is darkening the text.

Combined with the theme change this fixes the active state.

We could do this without taking secondary but I think we should consider the alignment.

A slight wash for hover would be a nice upstream improvement but that needs a proper brand.50 (or maybe regrading of the ramp, deferred to brand ramp review).