### PR TITLE
Drop the no-op isRound prop from icon buttons

### DIFF
--- a/src/editor/UndoRedoControls.tsx
+++ b/src/editor/UndoRedoControls.tsx
@@ -31,7 +31,6 @@ const UndoRedoControls = ({ css: cssProp }: UndoRedoControlsProps) => {
       }}
     >
       <IconButton
-        isRound
         variant="neutral"
         aria-label={intl.formatMessage({ id: "undo" })}
         onPress={actions?.undo}
@@ -40,7 +39,6 @@ const UndoRedoControls = ({ css: cssProp }: UndoRedoControlsProps) => {
         <RiArrowGoBackLine style={{ transform: "rotate(-90deg)" }} />
       </IconButton>
       <IconButton
-        isRound
         variant="neutral"
         css={{ borderLeft: "1px solid", borderLeftColor: "gray.10" }}
         aria-label={intl.formatMessage({ id: "redo" })}

--- a/src/editor/ZoomControls.tsx
+++ b/src/editor/ZoomControls.tsx
@@ -46,7 +46,6 @@ const ZoomControls = ({ size, css: cssProp }: ZoomControlsProps) => {
     <ButtonGroup css={cssProp} isAttached>
       <IconButton
         size={size}
-        isRound
         variant="neutral"
         aria-label={intl.formatMessage({ id: "zoom-out-action" })}
         onPress={handleZoomOut}
@@ -56,7 +55,6 @@ const ZoomControls = ({ size, css: cssProp }: ZoomControlsProps) => {
       <IconButton
         css={{ borderLeft: "1px solid", borderLeftColor: "gray.10" }}
         size={size}
-        isRound
         variant="neutral"
         aria-label={intl.formatMessage({ id: "zoom-in-action" })}
         onPress={handleZoomIn}

--- a/src/serial/SerialBar.tsx
+++ b/src/serial/SerialBar.tsx
@@ -120,7 +120,6 @@ const SerialBar = ({
             {showHintsAndTips && (
               <IconButton
                 variant="sidebar"
-                isRound
                 aria-label={intl.formatMessage({ id: "serial-hints-and-tips" })}
                 onPress={handleShowHintsAndTips}
               >

--- a/src/serial/SerialMenu.tsx
+++ b/src/serial/SerialMenu.tsx
@@ -38,7 +38,6 @@ const SerialMenu = React.forwardRef(
           ref={menuButtonRef}
           aria-label={intl.formatMessage({ id: "serial-menu" })}
           variant="sidebar"
-          isRound
         >
           <MdMoreVert />
         </IconButton>

--- a/src/settings/SettingsMenu.tsx
+++ b/src/settings/SettingsMenu.tsx
@@ -49,7 +49,6 @@ const SettingsMenu = ({ size }: SettingsMenuProps) => {
           size={size}
           css={{ fontSize: "xl" }}
           variant="sidebar"
-          isRound
         >
           <RiSettings2Line />
         </IconButton>

--- a/src/workbench/HelpMenu.tsx
+++ b/src/workbench/HelpMenu.tsx
@@ -64,7 +64,6 @@ const HelpMenu = ({ size }: HelpMenuProps) => {
           size={size}
           css={{ fontSize: "xl" }}
           variant="sidebar"
-          isRound
         >
           <RiQuestionLine />
         </IconButton>


### PR DESCRIPTION
It is being removed from @microbit/ui: the 2rem button radius already clamps to a full round at every size, so the prop changed nothing here. No visual change.

See microbit-foundation/ui#4