### PR TITLE
Use npm-package-versioner-action for version stamping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,6 @@ env:
   DEPLOY_AWS_VERSION: "0.6.0"
   # renovate: datasource=npm depName=@microbit-foundation/website-deploy-aws-config registryUrl=https://npm.pkg.github.com
   DEPLOY_AWS_CONFIG_VERSION: "0.9.0"
-  # renovate: datasource=npm depName=@microbit-foundation/circleci-npm-package-versioner registryUrl=https://npm.pkg.github.com
-  VERSIONER_VERSION: "1"
 
 jobs:
   build:
@@ -49,17 +47,16 @@ jobs:
           cache: "npm"
           registry-url: "https://npm.pkg.github.com"
       - run: npm install -g npm@${{ env.NPM_VERSION }} --registry=https://registry.npmjs.org
+      - uses: microbit-foundation/npm-package-versioner-action@v3
       - run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: npm install --no-save @microbit-foundation/python-editor-v3-microbit@${{ env.THEME_VERSION }} @microbit-foundation/website-deploy-aws@${{ env.DEPLOY_AWS_VERSION }} @microbit-foundation/website-deploy-aws-config@${{ env.DEPLOY_AWS_CONFIG_VERSION }} @microbit-foundation/circleci-npm-package-versioner@${{ env.VERSIONER_VERSION }}
+      - run: npm install --no-save @microbit-foundation/python-editor-v3-microbit@${{ env.THEME_VERSION }} @microbit-foundation/website-deploy-aws@${{ env.DEPLOY_AWS_VERSION }} @microbit-foundation/website-deploy-aws-config@${{ env.DEPLOY_AWS_CONFIG_VERSION }}
         if: github.repository_owner == 'microbit-foundation'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: node ./bin/print-ci-env-stage.cjs >> $GITHUB_ENV
       - run: node ./bin/print-ci-env-public-url.cjs >> $GITHUB_ENV
-      - run: npm run ci:update-version
-        if: github.repository_owner == 'microbit-foundation'
       - run: npm run ci
         env:
           VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
   "scripts": {
     "build": "vite build",
     "prebuild": "npm run panda",
-    "ci:update-version": "update-ci-version",
     "ci": "npm run typecheck && npm run test && npm run lint && npm run build",
     "deploy": "website-deploy-aws",
     "dev:link-ui": "rm -rf node_modules/@microbit/ui node_modules/@microbit/ui-patterns && ln -s ../../../ui/packages/ui node_modules/@microbit/ui && ln -s ../../../ui/packages/ui-patterns node_modules/@microbit/ui-patterns && rm -rf styled-system node_modules/.vite && npm run panda",


### PR DESCRIPTION
Replaces @microbit-foundation/circleci-npm-package-versioner, which the workflow installed via --no-save purely to run one script, with the equivalent GitHub Action. The action is public so version stamping no longer needs to be gated on the repository owner.

Prerelease versions for non-tag builds change format slightly, e.g. main is now 3.0.0-dev.<build>. Tag builds are unchanged, so the production deployment prefix is unaffected.