### PR TITLE
Improve test coverage for our use of CodeMirror

### DIFF
--- a/src/e2e/app.ts
+++ b/src/e2e/app.ts
@@ -3,7 +3,14 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { BrowserContext, Frame, Locator, Page, expect } from "@playwright/test";
+import {
+  BrowserContext,
+  Frame,
+  JSHandle,
+  Locator,
+  Page,
+  expect,
+} from "@playwright/test";
 import { Flag } from "../flags";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -558,6 +565,57 @@ export class App {
       .filter({ hasText: targetLine.toString() });
 
     await codeExample.dragTo(editorLine);
+  }
+
+  private dragDataTransfer: JSHandle<DataTransfer> | undefined;
+  private dragSource: Locator | undefined;
+
+  /**
+   * Starts dragging a code example and hovers it over the target line
+   * without dropping. Finish with dragCodeEmbedOffEditor and/or endDrag.
+   *
+   * The drag is synthesised with dispatched events as Playwright's mouse
+   * API cannot hold a real HTML5 drag mid-flight for assertions.
+   */
+  async startCodeEmbedDrag(name: string, targetLine: number) {
+    // The draggable element with the drag handlers, unlike getCodeExample
+    // which returns a nested div.
+    this.dragSource = this.page
+      .getByRole("listitem")
+      .filter({ hasText: name })
+      .getByRole("button")
+      .filter({ hasText: "Code example:" })
+      .first();
+    this.dragDataTransfer = await this.page.evaluateHandle(
+      () => new DataTransfer()
+    );
+    await this.dragSource.dispatchEvent("dragstart", {
+      dataTransfer: this.dragDataTransfer,
+    });
+    const editorLine = this.editor
+      .getByRole("textbox")
+      .locator("div")
+      .filter({ hasText: targetLine.toString() });
+    const target = (await editorLine.boundingBox())!;
+    await this.editorTextArea.dispatchEvent("dragover", {
+      dataTransfer: this.dragDataTransfer,
+      clientX: target.x + target.width / 2,
+      clientY: target.y + target.height / 2,
+    });
+  }
+
+  async dragCodeEmbedOffEditor() {
+    await this.editorTextArea.dispatchEvent("dragleave", {
+      dataTransfer: this.dragDataTransfer,
+    });
+  }
+
+  async endDrag() {
+    await this.dragSource!.dispatchEvent("dragend", {
+      dataTransfer: this.dragDataTransfer,
+    });
+    this.dragDataTransfer = undefined;
+    this.dragSource = undefined;
   }
 
   async search(searchText: string): Promise<void> {

--- a/src/e2e/diagnostics.test.ts
+++ b/src/e2e/diagnostics.test.ts
@@ -1,0 +1,65 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { expect } from "@playwright/test";
+import { test } from "./app-test-fixtures.js";
+import { App } from "./app.js";
+
+// Escape dismisses autocomplete so that Enter inserts a newline rather than
+// accepting a completion; the cursor then moves off the offending line,
+// otherwise the gutter shows the typing indicator rather than the error.
+const typeCodeWithError = async (app: App) => {
+  await app.selectAllInEditor();
+  await app.typeInEditor("from microbit import *\nfoo");
+  await app.page.keyboard.press("Escape");
+  await app.page.keyboard.press("Enter");
+};
+
+test.describe("diagnostics", () => {
+  test("shows an error marker and underline for invalid code", async ({
+    app,
+  }) => {
+    await typeCodeWithError(app);
+
+    await expect(app.page.locator(".cm-lint-marker-error")).toBeVisible();
+    await expect(app.page.locator(".cm-lintRange-error")).toBeVisible();
+  });
+
+  test("shows a typing indicator while editing the line", async ({ app }) => {
+    await app.selectAllInEditor();
+    // No Enter: the cursor stays on the offending line.
+    await app.typeInEditor("from microbit import *\nfoo");
+
+    await expect(app.page.locator(".cm-lint-marker-editing")).toBeVisible();
+    await expect(app.page.locator(".cm-lint-marker-error")).toHaveCount(0);
+
+    // Moving to another line reveals the real severity. Escape first so
+    // ArrowUp moves the cursor rather than navigating autocomplete.
+    await app.page.keyboard.press("Escape");
+    await app.page.keyboard.press("ArrowUp");
+    await expect(app.page.locator(".cm-lint-marker-error")).toBeVisible();
+    await expect(app.page.locator(".cm-lint-marker-editing")).toHaveCount(0);
+  });
+
+  test("clears the marker when the code is fixed", async ({ app }) => {
+    await typeCodeWithError(app);
+    await expect(app.page.locator(".cm-lint-marker-error")).toBeVisible();
+
+    await app.selectAllInEditor();
+    await app.typeInEditor("from microbit import *\ndisplay.show(1)");
+    await app.page.keyboard.press("Escape");
+    await app.page.keyboard.press("Enter");
+    await expect(app.page.locator(".cm-lint-marker")).toHaveCount(0);
+  });
+
+  test("shows the message when hovering the gutter marker", async ({ app }) => {
+    await typeCodeWithError(app);
+
+    const marker = app.page.locator(".cm-lint-marker-error");
+    await expect(marker).toBeVisible();
+    await marker.hover();
+    await expect(app.page.locator(".cm-tooltip-lint")).toContainText("foo");
+  });
+});

--- a/src/e2e/dnd.test.ts
+++ b/src/e2e/dnd.test.ts
@@ -1,0 +1,57 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { expect } from "@playwright/test";
+import { test } from "./app-test-fixtures.js";
+import { App } from "./app.js";
+
+const setupEditorAndSidebar = async (app: App) => {
+  await app.selectAllInEditor();
+  await app.typeInEditor("#1\n#2\n#3\n");
+  await app.expectEditorContainText("#2");
+  await app.switchTab("Reference");
+  await app.selectDocumentationSection("Display");
+};
+
+test.describe("code example drag and drop", () => {
+  test("previews the snippet during a drag and reverts on drag out", async ({
+    app,
+  }) => {
+    await setupEditorAndSidebar(app);
+
+    await app.startCodeEmbedDrag("Scroll", 2);
+    await expect(app.page.locator(".cm-preview").first()).toBeVisible();
+    // Our dropcursor fork suppresses the native drop cursor for snippet
+    // drags as the preview takes its place.
+    await expect(app.page.locator(".cm-dropCursor")).toHaveCount(0);
+
+    await app.dragCodeEmbedOffEditor();
+    await expect(app.page.locator(".cm-preview")).toHaveCount(0);
+    await app.endDrag();
+
+    await expect(app.editorTextArea).not.toContainText("display.scroll");
+    await expect(app.editorTextArea).not.toContainText("from microbit");
+    await app.expectEditorContainText("#2");
+  });
+
+  test("highlights dropped code and undoes the drop in one step", async ({
+    app,
+  }) => {
+    await setupEditorAndSidebar(app);
+
+    await app.dragDropCodeEmbed("Scroll", 2);
+    await app.expectEditorContainText("display.scroll('score')");
+    await expect(
+      app.page.locator(".cm-dropped--recent, .cm-dropped--done").first()
+    ).toBeVisible();
+
+    // The preview transactions are excluded from history so a single undo
+    // reverts the whole drop, imports included.
+    await app.page.keyboard.press(`${app.modifierKey}+z`);
+    await expect(app.editorTextArea).not.toContainText("display.scroll");
+    await expect(app.editorTextArea).not.toContainText("from microbit");
+    await app.expectEditorContainText("#2");
+  });
+});

--- a/src/e2e/structure-highlighting.test.ts
+++ b/src/e2e/structure-highlighting.test.ts
@@ -1,0 +1,63 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { expect } from "@playwright/test";
+import { test } from "./app-test-fixtures.js";
+
+const nestedProgram = "while True:\n    if True:\n        pass";
+
+test.describe("structure highlighting", () => {
+  test("draws indented blocks for nested statements", async ({ app }) => {
+    await app.selectAllInEditor();
+    await app.typeInEditor(nestedProgram);
+
+    const bodies = app.page.locator(".cm-cs--body");
+    await expect(app.page.locator(".cm-cs--parent")).toHaveCount(2);
+    await expect(bodies).toHaveCount(2);
+
+    // Drawn outermost first; the nested body is indented further.
+    const lefts = await bodies.evaluateAll((elements) =>
+      elements.map((e) => parseFloat((e as HTMLElement).style.left))
+    );
+    expect(lefts[1]).toBeGreaterThan(lefts[0]);
+  });
+
+  test("marks the innermost block containing the cursor as active", async ({
+    app,
+  }) => {
+    await app.selectAllInEditor();
+    // Leaves the cursor at the end, inside the if body.
+    await app.typeInEditor(nestedProgram);
+
+    const bodies = app.page.locator(".cm-cs--body");
+    await expect(bodies).toHaveCount(2);
+    await expect(bodies.nth(1)).toHaveClass(/cm-cs--active/);
+    await expect(bodies.nth(0)).not.toHaveClass(/cm-cs--active/);
+
+    // Moving the cursor to the while line moves the highlight.
+    await app.page.getByText("while True:").click();
+    await expect(bodies.nth(0)).toHaveClass(/cm-cs--active/);
+    await expect(bodies.nth(1)).not.toHaveClass(/cm-cs--active/);
+  });
+
+  test("follows the highlight code structure setting", async ({ app }) => {
+    await app.selectAllInEditor();
+    await app.typeInEditor(nestedProgram);
+    await expect(
+      app.page.locator(".cm-cs--layer.cm-cs--mode-full")
+    ).toHaveCount(1);
+
+    await app.page.getByTestId("settings").click();
+    await app.page.getByRole("menuitem", { name: "Settings" }).click();
+    const select = app.page.getByLabel("Highlight code structure");
+    await select.selectOption("simple");
+    await expect(
+      app.page.locator(".cm-cs--layer.cm-cs--mode-simple")
+    ).toHaveCount(1);
+
+    await select.selectOption("none");
+    await expect(app.page.locator(".cm-cs--layer")).toHaveCount(0);
+  });
+});

--- a/src/editor/codemirror/dropcursor.ts
+++ b/src/editor/codemirror/dropcursor.ts
@@ -23,7 +23,13 @@
  */
 
 /**
- * Edited from https://github.com/codemirror/view/blob/main/src/dropcursor.ts
+ * Modified copy of the dropcursor extension from @codemirror/view 0.19.44
+ * https://github.com/codemirror/view/blob/0.19.44/src/dropcursor.ts
+ *
+ * Changes:
+ * - The drop cursor is not shown for drags carrying our Python snippet
+ *   media type, as the dnd extension previews those directly in the
+ *   document instead.
  */
 
 import { StateField, StateEffect, Extension } from "@codemirror/state";

--- a/src/editor/codemirror/language-server/autocompletion.test.ts
+++ b/src/editor/codemirror/language-server/autocompletion.test.ts
@@ -1,0 +1,268 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { CompletionContext, CompletionResult } from "@codemirror/autocomplete";
+import { python } from "@codemirror/lang-python";
+import {
+  EditorState,
+  EditorSelection,
+  Extension,
+  TransactionSpec,
+} from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { createIntl } from "react-intl";
+import { MockedFunction, vi } from "vitest";
+import {
+  CompletionItem,
+  CompletionItemKind,
+  CompletionTriggerKind,
+} from "vscode-languageserver-protocol";
+import { LanguageServerClient } from "../../../language-server/client";
+import { Logging } from "../../../logging/logging";
+import { createCompletionSource } from "./autocompletion";
+import { clientFacet, uriFacet } from "./common";
+
+const intl = createIntl({ locale: "en", messages: {} });
+
+const createLogging = (): Logging => ({
+  event: vi.fn(),
+  error: vi.fn(),
+  log: vi.fn(),
+});
+
+const createClient = (
+  items: CompletionItem[] = [],
+  capabilities: {} | undefined = {
+    completionProvider: { triggerCharacters: ["."] },
+  }
+): LanguageServerClient =>
+  ({
+    capabilities,
+    completionRequest: vi
+      .fn()
+      .mockResolvedValue({ isIncomplete: false, items }),
+    connection: { sendRequest: vi.fn() },
+  } as unknown as LanguageServerClient);
+
+const completionRequestMock = (client: LanguageServerClient) =>
+  client.completionRequest as unknown as MockedFunction<
+    LanguageServerClient["completionRequest"]
+  >;
+
+/**
+ * The cursor position is marked with █, following edits.test.ts.
+ */
+const createContext = (
+  docWithCursor: string,
+  {
+    explicit = false,
+    client = createClient(),
+    extraExtensions = [],
+  }: {
+    explicit?: boolean;
+    client?: LanguageServerClient | null;
+    extraExtensions?: Extension[];
+  } = {}
+): CompletionContext => {
+  const pos = docWithCursor.indexOf("█");
+  const doc = docWithCursor.replace("█", "");
+  const state = EditorState.create({
+    doc,
+    selection: EditorSelection.single(pos),
+    extensions: [
+      python(),
+      client ? clientFacet.of(client) : [],
+      uriFacet.of("file:///src/main.py"),
+      ...extraExtensions,
+    ],
+  });
+  return new CompletionContext(state, pos, explicit);
+};
+
+const source = createCompletionSource(intl, createLogging(), {});
+
+describe("createCompletionSource", () => {
+  it("returns null without a client", async () => {
+    expect(await source(createContext("dis█", { client: null }))).toBeNull();
+  });
+
+  it("returns null when the server has no completion capability", async () => {
+    const client = createClient([], {});
+    expect(await source(createContext("dis█", { client }))).toBeNull();
+    expect(completionRequestMock(client)).not.toHaveBeenCalled();
+  });
+
+  it("triggers as invoked when typing an identifier", async () => {
+    const client = createClient();
+    const result = await source(createContext("dis█", { client }));
+    expect(result).not.toBeNull();
+    // Completion applies from the start of the identifier.
+    expect(result!.from).toEqual(0);
+    expect(completionRequestMock(client)).toHaveBeenCalledWith({
+      textDocument: { uri: "file:///src/main.py" },
+      position: { line: 0, character: 3 },
+      context: {
+        triggerKind: CompletionTriggerKind.Invoked,
+        triggerCharacter: undefined,
+      },
+    });
+  });
+
+  it("triggers as invoked for explicit requests", async () => {
+    const client = createClient();
+    const result = await source(createContext("█", { client, explicit: true }));
+    expect(result).not.toBeNull();
+    expect(result!.from).toEqual(0);
+    expect(
+      completionRequestMock(client).mock.calls[0][0].context?.triggerKind
+    ).toEqual(CompletionTriggerKind.Invoked);
+  });
+
+  it("triggers on trigger characters", async () => {
+    const client = createClient();
+    const result = await source(createContext("display.█", { client }));
+    expect(result).not.toBeNull();
+    expect(result!.from).toEqual(8);
+    expect(completionRequestMock(client).mock.calls[0][0].context).toEqual({
+      triggerKind: CompletionTriggerKind.TriggerCharacter,
+      triggerCharacter: ".",
+    });
+  });
+
+  it("returns null when there is nothing to trigger on", async () => {
+    const client = createClient();
+    expect(await source(createContext("display █", { client }))).toBeNull();
+    expect(completionRequestMock(client)).not.toHaveBeenCalled();
+  });
+
+  it("filters out completions with additional text edits", async () => {
+    const client = createClient([
+      { label: "one", data: {} },
+      {
+        label: "two",
+        data: {},
+        additionalTextEdits: [
+          {
+            range: {
+              start: { line: 0, character: 0 },
+              end: { line: 0, character: 0 },
+            },
+            newText: "import radio\n",
+          },
+        ],
+      },
+    ]);
+    const result = await source(createContext("█", { client, explicit: true }));
+    expect(result!.options.map((o) => o.label)).toEqual(["one"]);
+  });
+
+  it("orders by sortText falling back to label", async () => {
+    const client = createClient([
+      { label: "b", data: {}, sortText: "2" },
+      { label: "a", data: {}, sortText: "3" },
+      { label: "c", data: {}, sortText: "1" },
+      { label: "d", data: {} },
+    ]);
+    const result = await source(createContext("█", { client, explicit: true }));
+    expect(result!.options.map((o) => o.label)).toEqual(["c", "b", "a", "d"]);
+  });
+
+  it("maps completion item kinds to CodeMirror types", async () => {
+    const client = createClient([
+      { label: "scroll", data: {}, kind: CompletionItemKind.Function },
+      { label: "clear", data: {}, kind: CompletionItemKind.Method },
+      { label: "button_a", data: {}, kind: CompletionItemKind.Variable },
+      { label: "unspecified", data: {} },
+    ]);
+    const result = await source(createContext("█", { client, explicit: true }));
+    expect(result!.options.map((o) => o.type)).toEqual([
+      "variable",
+      "method",
+      "function",
+      undefined,
+    ]);
+  });
+
+  it("demotes dunder and keyword-argument completions", async () => {
+    const client = createClient([
+      { label: "__init__", data: {} },
+      { label: "image=", data: {} },
+      { label: "Image", data: {} },
+    ]);
+    const result = await source(createContext("█", { client, explicit: true }));
+    const boosts = new Map(result!.options.map((o) => [o.label, o.boost]));
+    expect(boosts.get("__init__")).toEqual(-99);
+    // The magnitude is coupled to @codemirror/autocomplete's ranking; see boost().
+    expect(boosts.get("image=")).toBeLessThanOrEqual(-200);
+    expect(boosts.get("Image")).toBeUndefined();
+  });
+
+  describe("apply", () => {
+    const applyOption = async (
+      docWithCursor: string,
+      items: CompletionItem[]
+    ) => {
+      const logging = createLogging();
+      const source = createCompletionSource(intl, logging, {});
+      const client = createClient(items);
+      const context = createContext(docWithCursor, { client });
+      const result = (await source(context)) as CompletionResult;
+      const option = result.options[0];
+      let state = context.state;
+      const view = {
+        get state() {
+          return state;
+        },
+        dispatch: (...specs: TransactionSpec[]) => {
+          state = state.update(...specs).state;
+        },
+      } as unknown as EditorView;
+      if (typeof option.apply !== "function") {
+        throw new Error("Expected a function apply");
+      }
+      option.apply(view, option, result.from, context.pos);
+      return { state, logging };
+    };
+
+    it("inserts the label", async () => {
+      const { state, logging } = await applyOption("but█", [
+        { label: "button_a", data: {}, kind: CompletionItemKind.Variable },
+      ]);
+      expect(state.doc.toString()).toEqual("button_a");
+      expect(state.selection.main.from).toEqual("button_a".length);
+      expect(logging.event).toHaveBeenCalledWith({
+        type: "autocomplete-accept",
+      });
+    });
+
+    it("inserts brackets for functions with the cursor between them", async () => {
+      const { state } = await applyOption("sle█", [
+        { label: "sleep", data: {}, kind: CompletionItemKind.Function },
+      ]);
+      expect(state.doc.toString()).toEqual("sleep()");
+      expect(state.selection.main.from).toEqual("sleep(".length);
+    });
+
+    it("inserts brackets for methods", async () => {
+      const { state } = await applyOption("display.scr█", [
+        { label: "scroll", data: {}, kind: CompletionItemKind.Method },
+      ]);
+      expect(state.doc.toString()).toEqual("display.scroll()");
+      expect(state.selection.main.from).toEqual("display.scroll(".length);
+    });
+
+    it("skips brackets when Pyright disables them", async () => {
+      // Pyright sets funcParensDisabled for e.g. function completions in imports.
+      const { state } = await applyOption("from microbit import sle█", [
+        {
+          label: "sleep",
+          data: { funcParensDisabled: true },
+          kind: CompletionItemKind.Function,
+        },
+      ]);
+      expect(state.doc.toString()).toEqual("from microbit import sleep");
+    });
+  });
+});

--- a/src/editor/codemirror/language-server/autocompletion.test.ts
+++ b/src/editor/codemirror/language-server/autocompletion.test.ts
@@ -253,6 +253,14 @@ describe("createCompletionSource", () => {
       expect(state.selection.main.from).toEqual("display.scroll(".length);
     });
 
+    it("inserts brackets for functions without LSP data", async () => {
+      // data is optional in LSP even though Pyright always sends it.
+      const { state } = await applyOption("sle█", [
+        { label: "sleep", kind: CompletionItemKind.Function },
+      ]);
+      expect(state.doc.toString()).toEqual("sleep()");
+    });
+
     it("skips brackets when Pyright disables them", async () => {
       // Pyright sets funcParensDisabled for e.g. function completions in imports.
       const { state } = await applyOption("from microbit import sle█", [

--- a/src/editor/codemirror/language-server/autocompletion.ts
+++ b/src/editor/codemirror/language-server/autocompletion.ts
@@ -119,7 +119,7 @@ export const createCompletionSource =
                 if (
                   // funcParensDisabled is set to true by Pyright for e.g. a function completion in an import
                   (completion.type === "function" &&
-                    !item.data.funcParensDisabled) ||
+                    !item.data?.funcParensDisabled) ||
                   completion.type === "method"
                 ) {
                   const bracketTransaction = insertBracket(view.state, "(");

--- a/src/editor/codemirror/language-server/autocompletion.ts
+++ b/src/editor/codemirror/language-server/autocompletion.ts
@@ -47,99 +47,101 @@ export const autocompletion = (
   apiReferenceMap: ApiReferenceMap
 ) =>
   cmAutocompletion({
-    override: [
-      async (context: CompletionContext): Promise<CompletionResult | null> => {
-        const client = context.state.facet(clientFacet);
-        const uri = context.state.facet(uriFacet);
-        if (!client || !uri || !client.capabilities?.completionProvider) {
-          return null;
-        }
-
-        let triggerKind: CompletionTriggerKind | undefined;
-        let triggerCharacter: string | undefined;
-        const before = context.matchBefore(identifierLike);
-        if (context.explicit || before) {
-          triggerKind = CompletionTriggerKind.Invoked;
-        } else {
-          const triggerCharactersRegExp = createTriggerCharactersRegExp(client);
-          const match =
-            triggerCharactersRegExp &&
-            context.matchBefore(triggerCharactersRegExp);
-          if (match) {
-            triggerKind = CompletionTriggerKind.TriggerCharacter;
-            triggerCharacter = match.text;
-          } else {
-            return null;
-          }
-        }
-
-        const documentationResolver = createDocumentationResolver(
-          client,
-          intl,
-          apiReferenceMap
-        );
-        const results = await client.completionRequest({
-          textDocument: {
-            uri,
-          },
-          position: offsetToPosition(context.state.doc, context.pos),
-          context: {
-            triggerKind,
-            triggerCharacter,
-          },
-        });
-        return {
-          from: before ? before.from : context.pos,
-          // Could vary these based on isIncomplete? Needs investigation.
-          // Very desirable to set most of the time to remove flicker.
-          filter: true,
-          validFor: identifierLike,
-          options: sortBy(
-            results.items
-              // For now we don't support these edits (they usually add imports).
-              .filter((x) => !x.additionalTextEdits)
-              .map((item) => {
-                const completion: AugmentedCompletion = {
-                  // In practice we don't get textEdit fields back from Pyright so the label is used.
-                  label: item.label,
-                  apply: (view, completion, from, to) => {
-                    logging.event({ type: "autocomplete-accept" });
-                    const insert = item.label;
-                    const transactions: TransactionSpec[] = [
-                      {
-                        changes: { from, to, insert },
-                        selection: { anchor: from + insert.length },
-                      },
-                    ];
-                    if (
-                      // funcParensDisabled is set to true by Pyright for e.g. a function completion in an import
-                      (completion.type === "function" &&
-                        !item.data.funcParensDisabled) ||
-                      completion.type === "method"
-                    ) {
-                      const bracketTransaction = insertBracket(view.state, "(");
-                      if (bracketTransaction) {
-                        transactions.push(bracketTransaction);
-                      }
-                    }
-                    view.dispatch(...transactions);
-                  },
-                  type: item.kind ? mapCompletionKind[item.kind] : undefined,
-                  detail: item.detail,
-                  info: documentationResolver,
-                  boost: boost(item),
-                  // Needed later for resolving.
-                  item,
-                };
-                return completion;
-              }),
-            (item) => item.item.sortText ?? item.label
-          ),
-        };
-      },
-    ],
+    override: [createCompletionSource(intl, logging, apiReferenceMap)],
     closeOnBlur: false,
   });
+
+// Exported for unit testing.
+export const createCompletionSource =
+  (intl: IntlShape, logging: Logging, apiReferenceMap: ApiReferenceMap) =>
+  async (context: CompletionContext): Promise<CompletionResult | null> => {
+    const client = context.state.facet(clientFacet);
+    const uri = context.state.facet(uriFacet);
+    if (!client || !uri || !client.capabilities?.completionProvider) {
+      return null;
+    }
+
+    let triggerKind: CompletionTriggerKind | undefined;
+    let triggerCharacter: string | undefined;
+    const before = context.matchBefore(identifierLike);
+    if (context.explicit || before) {
+      triggerKind = CompletionTriggerKind.Invoked;
+    } else {
+      const triggerCharactersRegExp = createTriggerCharactersRegExp(client);
+      const match =
+        triggerCharactersRegExp && context.matchBefore(triggerCharactersRegExp);
+      if (match) {
+        triggerKind = CompletionTriggerKind.TriggerCharacter;
+        triggerCharacter = match.text;
+      } else {
+        return null;
+      }
+    }
+
+    const documentationResolver = createDocumentationResolver(
+      client,
+      intl,
+      apiReferenceMap
+    );
+    const results = await client.completionRequest({
+      textDocument: {
+        uri,
+      },
+      position: offsetToPosition(context.state.doc, context.pos),
+      context: {
+        triggerKind,
+        triggerCharacter,
+      },
+    });
+    return {
+      from: before ? before.from : context.pos,
+      // Could vary these based on isIncomplete? Needs investigation.
+      // Very desirable to set most of the time to remove flicker.
+      filter: true,
+      validFor: identifierLike,
+      options: sortBy(
+        results.items
+          // For now we don't support these edits (they usually add imports).
+          .filter((x) => !x.additionalTextEdits)
+          .map((item) => {
+            const completion: AugmentedCompletion = {
+              // In practice we don't get textEdit fields back from Pyright so the label is used.
+              label: item.label,
+              apply: (view, completion, from, to) => {
+                logging.event({ type: "autocomplete-accept" });
+                const insert = item.label;
+                const transactions: TransactionSpec[] = [
+                  {
+                    changes: { from, to, insert },
+                    selection: { anchor: from + insert.length },
+                  },
+                ];
+                if (
+                  // funcParensDisabled is set to true by Pyright for e.g. a function completion in an import
+                  (completion.type === "function" &&
+                    !item.data.funcParensDisabled) ||
+                  completion.type === "method"
+                ) {
+                  const bracketTransaction = insertBracket(view.state, "(");
+                  if (bracketTransaction) {
+                    transactions.push(bracketTransaction);
+                  }
+                }
+                view.dispatch(...transactions);
+              },
+              type: item.kind ? mapCompletionKind[item.kind] : undefined,
+              detail: item.detail,
+              info: documentationResolver,
+              boost: boost(item),
+              // Needed later for resolving.
+              item,
+            };
+            return completion;
+          }),
+        (item) => item.item.sortText ?? item.label
+      ),
+    };
+  };
 
 const createDocumentationResolver =
   (

--- a/src/editor/codemirror/language-server/diagnostics.test.ts
+++ b/src/editor/codemirror/language-server/diagnostics.test.ts
@@ -1,0 +1,140 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { Text } from "@codemirror/state";
+import { ConnectionStatus } from "@microbit/microbit-connection";
+import { MicrobitUSBConnection } from "@microbit/microbit-connection/usb";
+import * as LSP from "vscode-languageserver-protocol";
+import { Action } from "../lint/lint";
+import { diagnosticsMapping } from "./diagnostics";
+
+const createDevice = (
+  status: ConnectionStatus,
+  boardVersion: string | undefined
+): MicrobitUSBConnection =>
+  ({
+    status,
+    getBoardVersion: () => boardVersion,
+  } as unknown as MicrobitUSBConnection);
+
+const v1Device = createDevice(ConnectionStatus.Connected, "V1");
+const v2Device = createDevice(ConnectionStatus.Connected, "V2");
+const disconnectedDevice = createDevice(
+  ConnectionStatus.Disconnected,
+  undefined
+);
+
+const action: Action = {
+  name: "Test action",
+  apply: () => {},
+};
+
+const lspDiagnostic = (
+  overrides: Partial<LSP.Diagnostic> = {}
+): LSP.Diagnostic => ({
+  range: {
+    start: { line: 0, character: 0 },
+    end: { line: 0, character: 4 },
+  },
+  message: "Oops",
+  ...overrides,
+});
+
+const document = Text.of(["pass", "pass"]);
+
+const map = (
+  diagnostics: LSP.Diagnostic[],
+  device: MicrobitUSBConnection = disconnectedDevice,
+  warnOnV2OnlyFeatures: boolean = true
+) =>
+  diagnosticsMapping(
+    document,
+    diagnostics,
+    device,
+    warnOnV2OnlyFeatures,
+    () => action
+  );
+
+describe("diagnosticsMapping", () => {
+  it("maps position, message and severity", () => {
+    expect(
+      map([lspDiagnostic({ severity: LSP.DiagnosticSeverity.Error })])
+    ).toEqual([
+      {
+        from: 0,
+        to: 4,
+        severity: "error",
+        message: "Oops",
+        tags: undefined,
+        actions: [],
+      },
+    ]);
+  });
+
+  it("maps each severity", () => {
+    const severities = map([
+      lspDiagnostic({ severity: LSP.DiagnosticSeverity.Error }),
+      lspDiagnostic({ severity: LSP.DiagnosticSeverity.Warning }),
+      lspDiagnostic({ severity: LSP.DiagnosticSeverity.Information }),
+      lspDiagnostic({ severity: LSP.DiagnosticSeverity.Hint }),
+    ]).map((d) => d.severity);
+    expect(severities).toEqual(["error", "warning", "info", "hint"]);
+  });
+
+  it("defaults missing severity to warning", () => {
+    expect(map([lspDiagnostic()])[0].severity).toEqual("warning");
+  });
+
+  it("maps positions on later lines", () => {
+    const diagnostic = lspDiagnostic({
+      range: {
+        start: { line: 1, character: 0 },
+        end: { line: 1, character: 4 },
+      },
+    });
+    expect(map([diagnostic])[0]).toMatchObject({ from: 5, to: 9 });
+  });
+
+  it("converts tags", () => {
+    const diagnostic = lspDiagnostic({
+      tags: [LSP.DiagnosticTag.Unnecessary, LSP.DiagnosticTag.Deprecated],
+    });
+    expect(map([diagnostic])[0].tags).toEqual(["unnecessary", "deprecated"]);
+  });
+
+  it("skips diagnostics that don't map to the document", () => {
+    const diagnostic = lspDiagnostic({
+      range: {
+        start: { line: 10, character: 0 },
+        end: { line: 10, character: 4 },
+      },
+    });
+    expect(map([diagnostic])).toEqual([]);
+  });
+
+  describe("micro:bit V2-only API warnings", () => {
+    const v2OnlyDiagnostic = lspDiagnostic({
+      code: "reportMicrobitVersionApiUnsupported",
+    });
+
+    it("shown with action when a V1 board is connected", () => {
+      const result = map([v2OnlyDiagnostic], v1Device);
+      expect(result).toHaveLength(1);
+      expect(result[0].actions).toEqual([action]);
+    });
+
+    it("suppressed when the setting is off", () => {
+      expect(map([v2OnlyDiagnostic], v1Device, false)).toEqual([]);
+    });
+
+    it("suppressed when a V2 board is connected", () => {
+      expect(map([v2OnlyDiagnostic], v2Device)).toEqual([]);
+    });
+
+    it("suppressed when no board is connected", () => {
+      expect(map([v2OnlyDiagnostic], disconnectedDevice)).toEqual([]);
+    });
+  });
+});

--- a/src/editor/codemirror/language-server/names.test.ts
+++ b/src/editor/codemirror/language-server/names.test.ts
@@ -1,0 +1,31 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { nameFromSignature, removeFullyQualifiedName } from "./names";
+
+describe("removeFullyQualifiedName", () => {
+  it("strips module prefix keeping the signature", () => {
+    expect(removeFullyQualifiedName("microbit.display.scroll(text)")).toEqual(
+      "scroll(text)"
+    );
+  });
+  it("leaves unqualified names alone", () => {
+    expect(removeFullyQualifiedName("sleep(ms)")).toEqual("sleep(ms)");
+  });
+  it("copes with empty parameter list", () => {
+    expect(removeFullyQualifiedName("microbit.reset()")).toEqual("reset()");
+  });
+});
+
+describe("nameFromSignature", () => {
+  it("returns the fully qualified name", () => {
+    expect(nameFromSignature("microbit.display.scroll(text)")).toEqual(
+      "microbit.display.scroll"
+    );
+  });
+  it("returns the name for unqualified signatures", () => {
+    expect(nameFromSignature("sleep(ms)")).toEqual("sleep");
+  });
+});

--- a/src/editor/codemirror/language-server/regexp-util.test.ts
+++ b/src/editor/codemirror/language-server/regexp-util.test.ts
@@ -1,0 +1,23 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { escapeRegExp } from "./regexp-util";
+
+describe("escapeRegExp", () => {
+  it("escapes special characters", () => {
+    const regExp = new RegExp("^" + escapeRegExp(".[]()*+?^$") + "$");
+    expect(regExp.test(".[]()*+?^$")).toEqual(true);
+    expect(regExp.test("x")).toEqual(false);
+  });
+  it("leaves other characters alone", () => {
+    expect(escapeRegExp("abc_123")).toEqual("abc_123");
+  });
+  it("matches literal dot only", () => {
+    // The autocompletion trigger character case.
+    const regExp = new RegExp("[" + escapeRegExp(".") + "]");
+    expect(regExp.test(".")).toEqual(true);
+    expect(regExp.test("a")).toEqual(false);
+  });
+});

--- a/src/editor/codemirror/language-server/signatureHelp.test.ts
+++ b/src/editor/codemirror/language-server/signatureHelp.test.ts
@@ -1,0 +1,182 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { EditorState } from "@codemirror/state";
+import { showTooltip, Tooltip } from "@codemirror/view";
+import { createIntl } from "react-intl";
+import { SignatureHelp } from "vscode-languageserver-protocol";
+import {
+  setSignatureHelpRequestPosition,
+  setSignatureHelpResult,
+  signatureHelp,
+} from "./signatureHelp";
+
+const intl = createIntl({
+  locale: "en",
+  messages: { help: "Help", "api-tab": "API reference" },
+});
+
+const signatureHelpResult: SignatureHelp = {
+  signatures: [
+    {
+      label: "microbit.display.scroll(text, delay=150)",
+      parameters: [{ label: [24, 28] }, { label: [30, 39] }],
+      activeParameter: 0,
+      documentation: {
+        kind: "markdown",
+        value: "Scrolls text on the display.",
+      },
+    },
+  ],
+  activeSignature: 0,
+};
+
+const createState = (doc: string, automatic: boolean = true): EditorState =>
+  EditorState.create({
+    doc,
+    extensions: [signatureHelp(intl, automatic, {})],
+  });
+
+const tooltips = (state: EditorState): Tooltip[] =>
+  state.facet(showTooltip).filter((t): t is Tooltip => Boolean(t));
+
+describe("signatureHelp", () => {
+  it("shows no tooltip initially", () => {
+    expect(tooltips(createState("display.scroll()"))).toEqual([]);
+  });
+
+  it("shows no tooltip for a request until the result arrives", () => {
+    let state = createState("display.scroll()");
+    state = state.update({
+      effects: [setSignatureHelpRequestPosition.of(15)],
+    }).state;
+    expect(tooltips(state)).toEqual([]);
+
+    state = state.update({
+      effects: [setSignatureHelpResult.of(signatureHelpResult)],
+    }).state;
+    const shown = tooltips(state);
+    expect(shown).toHaveLength(1);
+    expect(shown[0].pos).toEqual(15);
+    expect(shown[0].above).toEqual(true);
+  });
+
+  it("renders the signature with the active parameter highlighted", () => {
+    let state = createState("display.scroll()");
+    state = state.update({
+      effects: [
+        setSignatureHelpRequestPosition.of(15),
+        setSignatureHelpResult.of(signatureHelpResult),
+      ],
+    }).state;
+    const { dom } = tooltips(state)[0].create({} as never);
+    expect(dom.className).toEqual("cm-signature-tooltip");
+    expect(dom.querySelector("code")!.textContent).toEqual(
+      // Fully qualified name trimmed for display.
+      "scroll(text, delay=150)"
+    );
+    expect(
+      dom.querySelector(".cm-signature-activeParameter")!.textContent
+    ).toEqual("text");
+    expect(dom.textContent).toContain("Scrolls text on the display.");
+  });
+
+  it("clears the tooltip when the result is cleared", () => {
+    let state = createState("display.scroll()");
+    state = state.update({
+      effects: [
+        setSignatureHelpRequestPosition.of(15),
+        setSignatureHelpResult.of(signatureHelpResult),
+      ],
+    }).state;
+    state = state.update({
+      effects: [setSignatureHelpResult.of(null)],
+    }).state;
+    expect(tooltips(state)).toEqual([]);
+  });
+
+  it("clears the tooltip when the position is cleared (close command)", () => {
+    let state = createState("display.scroll()");
+    state = state.update({
+      effects: [
+        setSignatureHelpRequestPosition.of(15),
+        setSignatureHelpResult.of(signatureHelpResult),
+      ],
+    }).state;
+    state = state.update({
+      effects: [setSignatureHelpRequestPosition.of(-1)],
+    }).state;
+    expect(tooltips(state)).toEqual([]);
+  });
+
+  it("maps the tooltip position through document changes", () => {
+    let state = createState("display.scroll()");
+    state = state.update({
+      effects: [
+        setSignatureHelpRequestPosition.of(15),
+        setSignatureHelpResult.of(signatureHelpResult),
+      ],
+    }).state;
+    state = state.update({
+      changes: { from: 0, insert: "x = " },
+    }).state;
+    expect(tooltips(state)[0].pos).toEqual(19);
+  });
+
+  it("follows explicit selection movement, keeping the stale result", () => {
+    let state = createState("display.scroll()");
+    state = state.update({
+      effects: [
+        setSignatureHelpRequestPosition.of(15),
+        setSignatureHelpResult.of(signatureHelpResult),
+      ],
+    }).state;
+    state = state.update({ selection: { anchor: 3 } }).state;
+    expect(tooltips(state)[0].pos).toEqual(3);
+  });
+
+  it("triggers automatically when typing ()", () => {
+    let state = createState("display.scroll");
+    state = state.update({
+      changes: { from: 14, insert: "()" },
+      selection: { anchor: 15 },
+      userEvent: "input.type",
+    }).state;
+    // The view plugin would request signature help for the new position;
+    // headless we just supply the result.
+    state = state.update({
+      effects: [setSignatureHelpResult.of(signatureHelpResult)],
+    }).state;
+    const shown = tooltips(state);
+    expect(shown).toHaveLength(1);
+    expect(shown[0].pos).toEqual(15);
+  });
+
+  it("does not trigger automatically when disabled", () => {
+    let state = createState("display.scroll", false);
+    state = state.update({
+      changes: { from: 14, insert: "()" },
+      selection: { anchor: 15 },
+      userEvent: "input.type",
+    }).state;
+    state = state.update({
+      effects: [setSignatureHelpResult.of(signatureHelpResult)],
+    }).state;
+    expect(tooltips(state)).toEqual([]);
+  });
+
+  it("does not trigger automatically for non-call input", () => {
+    let state = createState("display.scroll");
+    state = state.update({
+      changes: { from: 14, insert: "x" },
+      selection: { anchor: 15 },
+      userEvent: "input.type",
+    }).state;
+    state = state.update({
+      effects: [setSignatureHelpResult.of(signatureHelpResult)],
+    }).state;
+    expect(tooltips(state)).toEqual([]);
+  });
+});

--- a/src/editor/codemirror/language-server/signatureHelp.test.ts
+++ b/src/editor/codemirror/language-server/signatureHelp.test.ts
@@ -83,6 +83,35 @@ describe("signatureHelp", () => {
     expect(dom.textContent).toContain("Scrolls text on the display.");
   });
 
+  it("renders the first signature when activeSignature is omitted", () => {
+    // The LSP spec allows activeSignature to be omitted as well as null.
+    let state = createState("display.scroll()");
+    state = state.update({
+      effects: [
+        setSignatureHelpRequestPosition.of(15),
+        setSignatureHelpResult.of({
+          ...signatureHelpResult,
+          activeSignature: undefined,
+        }),
+      ],
+    }).state;
+    const { dom } = tooltips(state)[0].create({} as never);
+    expect(dom.querySelector("code")!.textContent).toEqual(
+      "scroll(text, delay=150)"
+    );
+  });
+
+  it("shows no tooltip for a result with no signatures", () => {
+    let state = createState("display.scroll()");
+    state = state.update({
+      effects: [
+        setSignatureHelpRequestPosition.of(15),
+        setSignatureHelpResult.of({ signatures: [] }),
+      ],
+    }).state;
+    expect(tooltips(state)).toEqual([]);
+  });
+
   it("clears the tooltip when the result is cleared", () => {
     let state = createState("display.scroll()");
     state = state.update({

--- a/src/editor/codemirror/language-server/signatureHelp.ts
+++ b/src/editor/codemirror/language-server/signatureHelp.ts
@@ -174,7 +174,7 @@ export const signatureHelp = (
     provide: (f) =>
       showTooltip.from(f, (val) => {
         const { result, pos } = val;
-        if (result) {
+        if (result && result.signatures.length > 0) {
           return {
             pos,
             above: true,
@@ -268,10 +268,11 @@ export const signatureHelp = (
   ): Node => {
     const { activeSignature: activeSignatureIndex, signatures } = help;
     // We intentionally do something minimal here to minimise distraction.
+    // The LSP spec allows activeSignature to be omitted as well as null.
     const activeSignature =
-      activeSignatureIndex === null
+      activeSignatureIndex == null
         ? signatures[0]
-        : signatures[activeSignatureIndex!];
+        : signatures[activeSignatureIndex];
     const {
       label,
       parameters,

--- a/src/editor/codemirror/lint/editingLine.test.ts
+++ b/src/editor/codemirror/lint/editingLine.test.ts
@@ -1,0 +1,175 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { ChangeSet, EditorState, StateEffect } from "@codemirror/state";
+import { ViewUpdate } from "@codemirror/view";
+import { MockedFunction, vi } from "vitest";
+import {
+  EditingLineViewPlugin,
+  editingLineState,
+  setEditingLineEffect,
+} from "./editingLine";
+
+describe("editingLineState", () => {
+  const createState = () =>
+    EditorState.create({
+      doc: "print('a')\nprint('b')",
+      extensions: [editingLineState],
+    });
+
+  it("starts unset", () => {
+    expect(createState().field(editingLineState)).toBeUndefined();
+  });
+
+  it("tracks the effect", () => {
+    let state = createState();
+    state = state.update({ effects: [setEditingLineEffect.of(2)] }).state;
+    expect(state.field(editingLineState)).toEqual(2);
+
+    // Unrelated transactions leave it alone.
+    state = state.update({ changes: { from: 0, insert: "x" } }).state;
+    expect(state.field(editingLineState)).toEqual(2);
+
+    state = state.update({
+      effects: [setEditingLineEffect.of(undefined)],
+    }).state;
+    expect(state.field(editingLineState)).toBeUndefined();
+  });
+});
+
+describe("EditingLineViewPlugin", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const createUpdate = (
+    state: EditorState,
+    changes: ChangeSet,
+    { docChanged, selectionSet }: { docChanged: boolean; selectionSet: boolean }
+  ): ViewUpdate => {
+    const dispatch = vi.fn();
+    const update = {
+      state,
+      changes,
+      docChanged,
+      selectionSet,
+      view: { dispatch } as unknown as ViewUpdate["view"],
+    } as Partial<ViewUpdate> as unknown as ViewUpdate;
+    return update;
+  };
+
+  const dispatchMock = (update: ViewUpdate) =>
+    update.view.dispatch as unknown as MockedFunction<
+      (spec: { effects: StateEffect<unknown>[] }) => void
+    >;
+
+  const editingLineEffectValues = (update: ViewUpdate) =>
+    dispatchMock(update).mock.calls.map(([spec]) => {
+      expect(spec.effects).toHaveLength(1);
+      expect(spec.effects[0].is(setEditingLineEffect)).toEqual(true);
+      return spec.effects[0].value;
+    });
+
+  const flushMicrotasks = () => new Promise<void>((r) => queueMicrotask(r));
+
+  const createState = (extraLines: number = 0) =>
+    EditorState.create({
+      doc: "print('a')\nprint('b')" + "\npass".repeat(extraLines),
+      extensions: [editingLineState],
+    });
+
+  it("marks the line as edited when a change happens at the cursor's line", async () => {
+    const base = createState();
+    const tr = base.update({
+      changes: { from: base.doc.length, insert: "x" },
+      selection: { anchor: base.doc.length + 1 },
+    });
+    const plugin = new EditingLineViewPlugin();
+    const update = createUpdate(tr.state, tr.changes, {
+      docChanged: true,
+      selectionSet: true,
+    });
+    plugin.update(update);
+    await flushMicrotasks();
+    expect(editingLineEffectValues(update)).toEqual([2]);
+  });
+
+  it("clears after the editing timeout", async () => {
+    const base = createState();
+    const tr = base.update({
+      changes: { from: base.doc.length, insert: "x" },
+      selection: { anchor: base.doc.length + 1 },
+    });
+    const plugin = new EditingLineViewPlugin();
+    const update = createUpdate(tr.state, tr.changes, {
+      docChanged: true,
+      selectionSet: true,
+    });
+    plugin.update(update);
+    await flushMicrotasks();
+    vi.advanceTimersByTime(5_000);
+    expect(editingLineEffectValues(update)).toEqual([2, undefined]);
+  });
+
+  it("clears when the selection moves to another line", async () => {
+    let state = createState();
+    state = state.update({ effects: [setEditingLineEffect.of(2)] }).state;
+    state = state.update({ selection: { anchor: 3 } }).state;
+    const plugin = new EditingLineViewPlugin();
+    const update = createUpdate(state, ChangeSet.empty(state.doc.length), {
+      docChanged: false,
+      selectionSet: true,
+    });
+    plugin.update(update);
+    await flushMicrotasks();
+    expect(editingLineEffectValues(update)).toEqual([undefined]);
+  });
+
+  it("does nothing when the cursor stays on the tracked line", async () => {
+    let state = createState();
+    state = state.update({ effects: [setEditingLineEffect.of(1)] }).state;
+    state = state.update({ selection: { anchor: 3 } }).state;
+    const plugin = new EditingLineViewPlugin();
+    const update = createUpdate(state, ChangeSet.empty(state.doc.length), {
+      docChanged: false,
+      selectionSet: true,
+    });
+    plugin.update(update);
+    await flushMicrotasks();
+    expect(dispatchMock(update)).not.toHaveBeenCalled();
+  });
+
+  it("ignores updates without document or selection changes", async () => {
+    const state = createState();
+    const plugin = new EditingLineViewPlugin();
+    const update = createUpdate(state, ChangeSet.empty(state.doc.length), {
+      docChanged: false,
+      selectionSet: false,
+    });
+    plugin.update(update);
+    await flushMicrotasks();
+    expect(dispatchMock(update)).not.toHaveBeenCalled();
+  });
+
+  it("does not mark edits away from the cursor's line", async () => {
+    const base = createState(2);
+    // Edit line 1 while the cursor is on line 4.
+    const tr = base.update({
+      changes: { from: 0, insert: "x" },
+      selection: { anchor: base.doc.length + 1 },
+    });
+    const plugin = new EditingLineViewPlugin();
+    const update = createUpdate(tr.state, tr.changes, {
+      docChanged: true,
+      selectionSet: true,
+    });
+    plugin.update(update);
+    await flushMicrotasks();
+    expect(editingLineEffectValues(update)).toEqual([undefined]);
+  });
+});

--- a/src/editor/codemirror/lint/editingLine.test.ts
+++ b/src/editor/codemirror/lint/editingLine.test.ts
@@ -99,6 +99,25 @@ describe("EditingLineViewPlugin", () => {
     expect(editingLineEffectValues(update)).toEqual([2]);
   });
 
+  it("marks the line as edited when typing at the start of the document", async () => {
+    const base = EditorState.create({
+      doc: "",
+      extensions: [editingLineState],
+    });
+    const tr = base.update({
+      changes: { from: 0, insert: "x" },
+      selection: { anchor: 0 },
+    });
+    const plugin = new EditingLineViewPlugin();
+    const update = createUpdate(tr.state, tr.changes, {
+      docChanged: true,
+      selectionSet: true,
+    });
+    plugin.update(update);
+    await flushMicrotasks();
+    expect(editingLineEffectValues(update)).toEqual([1]);
+  });
+
   it("clears after the editing timeout", async () => {
     const base = createState();
     const tr = base.update({

--- a/src/editor/codemirror/lint/editingLine.ts
+++ b/src/editor/codemirror/lint/editingLine.ts
@@ -12,58 +12,59 @@ import { ViewPlugin, ViewUpdate } from "@codemirror/view";
  */
 const editingTimeout = 5_000;
 
-/**
- * Plugin that maintains state tracking the line being edited.
- */
-export const editingLinePlugin = ViewPlugin.fromClass(
-  class {
-    timeout: any;
+// Exported for unit testing.
+export class EditingLineViewPlugin {
+  timeout: any;
 
-    update(update: ViewUpdate) {
-      if (!update.docChanged && !update.selectionSet) {
-        return;
-      }
-      const mainIndex = update.state.selection?.asSingle()?.ranges[0]?.from;
-      if (!mainIndex) {
-        return undefined;
-      }
-      const doc = update.state.doc;
-      const selectionLine = doc.lineAt(mainIndex).number;
-      let foundEditOnLine = false;
-      update.changes.iterChangedRanges((_fromA, _toA, fromB, _toB) => {
-        if (!foundEditOnLine && doc.lineAt(fromB).number === selectionLine) {
-          foundEditOnLine = true;
-          clearTimeout(this.timeout);
-          queueMicrotask(() => {
-            update.view.dispatch({
-              effects: [setEditingLineEffect.of(selectionLine)],
-            });
-          });
-          this.timeout = setTimeout(() => {
-            update.view.dispatch({
-              effects: [setEditingLineEffect.of(undefined)],
-            });
-          }, editingTimeout);
-        }
-      });
-      if (
-        !foundEditOnLine &&
-        update.state.field(editingLineState) !== selectionLine
-      ) {
+  update(update: ViewUpdate) {
+    if (!update.docChanged && !update.selectionSet) {
+      return;
+    }
+    const mainIndex = update.state.selection?.asSingle()?.ranges[0]?.from;
+    if (!mainIndex) {
+      return undefined;
+    }
+    const doc = update.state.doc;
+    const selectionLine = doc.lineAt(mainIndex).number;
+    let foundEditOnLine = false;
+    update.changes.iterChangedRanges((_fromA, _toA, fromB, _toB) => {
+      if (!foundEditOnLine && doc.lineAt(fromB).number === selectionLine) {
+        foundEditOnLine = true;
         clearTimeout(this.timeout);
         queueMicrotask(() => {
           update.view.dispatch({
-            effects: [setEditingLineEffect.of(undefined)],
+            effects: [setEditingLineEffect.of(selectionLine)],
           });
         });
+        this.timeout = setTimeout(() => {
+          update.view.dispatch({
+            effects: [setEditingLineEffect.of(undefined)],
+          });
+        }, editingTimeout);
       }
-    }
-
-    destroy() {
+    });
+    if (
+      !foundEditOnLine &&
+      update.state.field(editingLineState) !== selectionLine
+    ) {
       clearTimeout(this.timeout);
+      queueMicrotask(() => {
+        update.view.dispatch({
+          effects: [setEditingLineEffect.of(undefined)],
+        });
+      });
     }
   }
-);
+
+  destroy() {
+    clearTimeout(this.timeout);
+  }
+}
+
+/**
+ * Plugin that maintains state tracking the line being edited.
+ */
+export const editingLinePlugin = ViewPlugin.fromClass(EditingLineViewPlugin);
 
 /**
  * Effect when the currently edited line is changed.

--- a/src/editor/codemirror/lint/editingLine.ts
+++ b/src/editor/codemirror/lint/editingLine.ts
@@ -21,7 +21,7 @@ export class EditingLineViewPlugin {
       return;
     }
     const mainIndex = update.state.selection?.asSingle()?.ranges[0]?.from;
-    if (!mainIndex) {
+    if (mainIndex === undefined) {
       return undefined;
     }
     const doc = update.state.doc;

--- a/src/editor/codemirror/structure-highlighting/blocks.ts
+++ b/src/editor/codemirror/structure-highlighting/blocks.ts
@@ -1,0 +1,111 @@
+/**
+ * Extraction of the code blocks that structure highlighting draws from
+ * CodeMirror's syntax tree.
+ *
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { syntaxTree } from "@codemirror/language";
+import { EditorState } from "@codemirror/state";
+
+// Grammar is defined by https://github.com/lezer-parser/python/blob/master/src/python.grammar
+export const grammarInfo = {
+  compoundStatements: new Set([
+    "IfStatement",
+    "WhileStatement",
+    "ForStatement",
+    "TryStatement",
+    "WithStatement",
+    "FunctionDefinition",
+    "ClassDefinition",
+  ]),
+};
+
+/**
+ * A run of header nodes (e.g. "elif", a test expression) and the body
+ * that follows them. Positions are character offsets into the document.
+ * The body includes the colon and its end extends to the start of
+ * whatever follows the statement.
+ */
+export interface CodeBlock {
+  statement: string;
+  /**
+   * Start of the first header node of the run.
+   */
+  start: number;
+  bodyStart: number;
+  bodyEnd: number;
+  /**
+   * Indent depth of the header (1 per enclosing Body, starting at 0).
+   */
+  depth: number;
+}
+
+/**
+ * Extracts a block for each header/Body run of a compound statement.
+ *
+ * Blocks are returned in syntax tree leave order, i.e. innermost first,
+ * which the view relies on to attribute the cursor to the innermost
+ * enclosing block.
+ */
+export const codeBlocks = (state: EditorState): CodeBlock[] => {
+  const blocks: CodeBlock[] = [];
+  // We could throw away blocks if we tracked returning to the top-level or started from
+  // the closest top-level node. Otherwise we need to render them because they overlap.
+  // Should consider switching to tree cursors to avoid allocating syntax nodes.
+  let depth = 0;
+  const tree = syntaxTree(state);
+  const parents: {
+    name: string;
+    children?: { name: string; start: number; end: number }[];
+  }[] = [];
+  if (tree) {
+    tree.iterate({
+      enter: (node) => {
+        parents.push({ name: node.type.name });
+        if (node.type.name === "Body") {
+          depth++;
+        }
+      },
+      leave: (node) => {
+        if (node.type.name === "Body") {
+          depth--;
+        }
+
+        const leaving = parents.pop()!;
+        const children = leaving.children;
+        if (children) {
+          // A block for each run of non-Body (e.g. keywords, test expressions) followed by Body in the child list.
+          let runStart = 0;
+          for (let i = 0; i < children.length; ++i) {
+            if (children[i].name === "Body") {
+              blocks.push({
+                statement: leaving.name,
+                start: children[runStart].start,
+                bodyStart: children[i].start,
+                bodyEnd: children[i].end,
+                depth,
+              });
+              runStart = i + 1;
+            }
+          }
+        }
+
+        // Poke our information into our parent if we need to track it.
+        const parent = parents[parents.length - 1];
+        if (parent && grammarInfo.compoundStatements.has(parent.name)) {
+          if (!parent.children) {
+            parent.children = [];
+          }
+          parent.children.push({
+            name: node.type.name,
+            start: node.from,
+            end: node.to,
+          });
+        }
+      },
+    });
+  }
+  return blocks;
+};

--- a/src/editor/codemirror/structure-highlighting/doc-util.test.ts
+++ b/src/editor/codemirror/structure-highlighting/doc-util.test.ts
@@ -1,0 +1,91 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { EditorState } from "@codemirror/state";
+import { Decoration } from "@codemirror/view";
+import { overlapsUnnecessaryCode, skipBodyTrailers } from "./doc-util";
+
+// Mirrors the decoration spec used by lint.ts, which is what we read in practice.
+const diagnosticDecorations = (
+  ranges: { from: number; to: number; tags?: string[] }[]
+) =>
+  Decoration.set(
+    ranges.map(({ from, to, tags }) =>
+      Decoration.mark({ diagnostic: { tags } }).range(from, to)
+    )
+  );
+
+describe("skipBodyTrailers", () => {
+  // min=1 matches production usage in view.ts; the default of 0 is out of
+  // range for CodeMirror's 1-based line numbers.
+  const check = (doc: string, position: number) =>
+    skipBodyTrailers(EditorState.create({ doc }), undefined, position, 1);
+
+  it("returns end of line for content", () => {
+    const doc = "while True:\n    pass";
+    expect(check(doc, doc.length - 1)).toEqual(doc.length);
+  });
+
+  it("skips trailing blank lines", () => {
+    const doc = "while True:\n    pass\n\n\n";
+    expect(check(doc, doc.length - 1)).toEqual("while True:\n    pass".length);
+  });
+
+  it("skips whitespace-only lines", () => {
+    const doc = "while True:\n    pass\n   \n";
+    expect(check(doc, doc.length - 1)).toEqual("while True:\n    pass".length);
+  });
+
+  it("skips comment lines regardless of indent", () => {
+    const doc = "while True:\n    pass\n    # comment\n# comment\n";
+    expect(check(doc, doc.length - 1)).toEqual("while True:\n    pass".length);
+  });
+
+  it("returns undefined when everything is skippable", () => {
+    expect(check("# comment\n\n", 10)).toBeUndefined();
+  });
+
+  it("skips lines flagged as unnecessary code", () => {
+    const doc = "while True:\n    pass\n    unreachable()";
+    const state = EditorState.create({ doc });
+    const unreachableFrom = doc.indexOf("unreachable");
+    const hints = diagnosticDecorations([
+      { from: unreachableFrom, to: doc.length, tags: ["unnecessary"] },
+    ]);
+    expect(skipBodyTrailers(state, hints, doc.length - 1, 1)).toEqual(
+      "while True:\n    pass".length
+    );
+  });
+});
+
+describe("overlapsUnnecessaryCode", () => {
+  it("false for no decorations", () => {
+    expect(overlapsUnnecessaryCode(undefined, 0, 10)).toEqual(false);
+    expect(overlapsUnnecessaryCode(Decoration.none, 0, 10)).toEqual(false);
+  });
+
+  it("true for overlapping unnecessary diagnostic", () => {
+    const decorations = diagnosticDecorations([
+      { from: 5, to: 8, tags: ["unnecessary"] },
+    ]);
+    expect(overlapsUnnecessaryCode(decorations, 0, 10)).toEqual(true);
+    expect(overlapsUnnecessaryCode(decorations, 6, 7)).toEqual(true);
+  });
+
+  it("false for non-overlapping ranges", () => {
+    const decorations = diagnosticDecorations([
+      { from: 5, to: 8, tags: ["unnecessary"] },
+    ]);
+    expect(overlapsUnnecessaryCode(decorations, 20, 30)).toEqual(false);
+  });
+
+  it("false for other or missing tags", () => {
+    const decorations = diagnosticDecorations([
+      { from: 5, to: 8, tags: ["deprecated"] },
+      { from: 5, to: 8 },
+    ]);
+    expect(overlapsUnnecessaryCode(decorations, 0, 10)).toEqual(false);
+  });
+});

--- a/src/editor/codemirror/structure-highlighting/doc-util.test.ts
+++ b/src/editor/codemirror/structure-highlighting/doc-util.test.ts
@@ -18,8 +18,6 @@ const diagnosticDecorations = (
   );
 
 describe("skipBodyTrailers", () => {
-  // min=1 matches production usage in view.ts; the default of 0 is out of
-  // range for CodeMirror's 1-based line numbers.
   const check = (doc: string, position: number) =>
     skipBodyTrailers(EditorState.create({ doc }), undefined, position, 1);
 

--- a/src/editor/codemirror/structure-highlighting/doc-util.ts
+++ b/src/editor/codemirror/structure-highlighting/doc-util.ts
@@ -20,7 +20,7 @@ import { DecorationSet } from "@codemirror/view";
  * @param state Document state.
  * @param position Document character position.
  * @param hints The unreachable code hints.
- * @param min The minimum line to consider.
+ * @param min The minimum (1-based) line to consider.
  *
  * @returns End of last line we consider to be part of the body after
  *          skipping or undefined if we go past min.
@@ -29,7 +29,7 @@ export const skipBodyTrailers = (
   state: EditorState,
   hints: DecorationSet | undefined,
   position: number,
-  min: number = 0
+  min: number
 ): number | undefined => {
   for (
     let lineNumber = state.doc.lineAt(position).number;

--- a/src/editor/codemirror/structure-highlighting/grammar.test.ts
+++ b/src/editor/codemirror/structure-highlighting/grammar.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { python } from "@codemirror/lang-python";
-import { ensureSyntaxTree } from "@codemirror/language";
+import { syntaxTree } from "@codemirror/language";
 import { EditorState } from "@codemirror/state";
 import { codeBlocks, grammarInfo } from "./blocks";
 
@@ -19,9 +19,11 @@ import { codeBlocks, grammarInfo } from "./blocks";
 
 const createState = (doc: string): EditorState => {
   const state = EditorState.create({ doc, extensions: [python()] });
-  const tree = ensureSyntaxTree(state, doc.length, 10_000);
-  if (!tree) {
-    throw new Error("Parse did not complete");
+  // Headless, only the initial parse budget applies and codeBlocks reads
+  // syntaxTree(state), so a large document would silently produce a
+  // partial tree. Fine for the small documents here, but fail loudly.
+  if (syntaxTree(state).length < state.doc.length) {
+    throw new Error("Document too large for the initial headless parse");
   }
   return state;
 };

--- a/src/editor/codemirror/structure-highlighting/grammar.test.ts
+++ b/src/editor/codemirror/structure-highlighting/grammar.test.ts
@@ -1,0 +1,168 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { python } from "@codemirror/lang-python";
+import { ensureSyntaxTree } from "@codemirror/language";
+import { EditorState } from "@codemirror/state";
+import { codeBlocks, grammarInfo } from "./blocks";
+
+/**
+ * These tests pin the parts of the @lezer/python grammar that the code
+ * structure highlighting relies on: the node names in grammarInfo and
+ * the shape of compound statements as runs of header nodes each
+ * followed by a "Body" node. If a grammar upgrade renames or
+ * restructures these nodes the highlighting silently disappears, so we
+ * assert the contract here.
+ */
+
+const createState = (doc: string): EditorState => {
+  const state = EditorState.create({ doc, extensions: [python()] });
+  const tree = ensureSyntaxTree(state, doc.length, 10_000);
+  if (!tree) {
+    throw new Error("Parse did not complete");
+  }
+  return state;
+};
+
+interface BlockRun {
+  statement: string;
+  /** 1-based line of the start of the run (the if/elif/else etc. line). */
+  headerLine: number;
+  /** 1-based line of the last line of the body. */
+  bodyEndLine: number;
+  depth: number;
+}
+
+const blockRuns = (doc: string): BlockRun[] => {
+  const state = createState(doc);
+  const lineOf = (pos: number) => state.doc.lineAt(pos).number;
+  return codeBlocks(state)
+    .map(({ statement, start, bodyEnd, depth }) => ({
+      statement,
+      headerLine: lineOf(start),
+      // Body's "to" extends to the start of what follows, hence -1, as
+      // view.ts assumes when it uses skipBodyTrailers.
+      bodyEndLine: lineOf(bodyEnd - 1),
+      depth,
+    }))
+    .sort((a, b) => a.headerLine - b.headerLine);
+};
+
+describe("structure highlighting grammar contract", () => {
+  it("if/elif/else produces a run per branch", () => {
+    expect(
+      blockRuns("if a:\n    pass\nelif b:\n    pass\nelse:\n    pass\n")
+    ).toEqual([
+      { statement: "IfStatement", headerLine: 1, bodyEndLine: 2, depth: 0 },
+      { statement: "IfStatement", headerLine: 3, bodyEndLine: 4, depth: 0 },
+      { statement: "IfStatement", headerLine: 5, bodyEndLine: 6, depth: 0 },
+    ]);
+  });
+
+  it("while produces a single run", () => {
+    expect(blockRuns("while True:\n    pass\n    pass\n")).toEqual([
+      { statement: "WhileStatement", headerLine: 1, bodyEndLine: 3, depth: 0 },
+    ]);
+  });
+
+  it("for/else produces two runs", () => {
+    expect(blockRuns("for x in y:\n    pass\nelse:\n    pass\n")).toEqual([
+      { statement: "ForStatement", headerLine: 1, bodyEndLine: 2, depth: 0 },
+      { statement: "ForStatement", headerLine: 3, bodyEndLine: 4, depth: 0 },
+    ]);
+  });
+
+  it("try/except/finally produces a run per clause", () => {
+    expect(
+      blockRuns(
+        "try:\n    pass\nexcept ValueError:\n    pass\nfinally:\n    pass\n"
+      )
+    ).toEqual([
+      { statement: "TryStatement", headerLine: 1, bodyEndLine: 2, depth: 0 },
+      { statement: "TryStatement", headerLine: 3, bodyEndLine: 4, depth: 0 },
+      { statement: "TryStatement", headerLine: 5, bodyEndLine: 6, depth: 0 },
+    ]);
+  });
+
+  it("with produces a single run", () => {
+    expect(blockRuns("with open('f') as f:\n    pass\n")).toEqual([
+      { statement: "WithStatement", headerLine: 1, bodyEndLine: 2, depth: 0 },
+    ]);
+  });
+
+  it("function definitions produce a single run", () => {
+    expect(blockRuns("def foo(a, b=1):\n    pass\n")).toEqual([
+      {
+        statement: "FunctionDefinition",
+        headerLine: 1,
+        bodyEndLine: 2,
+        depth: 0,
+      },
+    ]);
+  });
+
+  it("class definitions produce a single run", () => {
+    expect(blockRuns("class Foo:\n    def bar(self):\n        pass\n")).toEqual(
+      [
+        {
+          statement: "ClassDefinition",
+          headerLine: 1,
+          bodyEndLine: 3,
+          depth: 0,
+        },
+        {
+          statement: "FunctionDefinition",
+          headerLine: 2,
+          bodyEndLine: 3,
+          depth: 1,
+        },
+      ]
+    );
+  });
+
+  it("nested statements produce runs at each level", () => {
+    expect(
+      blockRuns("while True:\n    if a:\n        pass\n    pass\n")
+    ).toEqual([
+      { statement: "WhileStatement", headerLine: 1, bodyEndLine: 4, depth: 0 },
+      { statement: "IfStatement", headerLine: 2, bodyEndLine: 3, depth: 1 },
+    ]);
+  });
+
+  it("returns blocks innermost first", () => {
+    // The view relies on this order to attribute the cursor to the
+    // innermost enclosing block.
+    const state = createState("while True:\n    if a:\n        pass\n");
+    expect(codeBlocks(state).map((b) => b.statement)).toEqual([
+      "IfStatement",
+      "WhileStatement",
+    ]);
+  });
+
+  it("single-line compound statements have body on the header line", () => {
+    // view.ts skips drawing these; it relies on the body resolving to the same line.
+    expect(blockRuns("if a: pass\n")).toEqual([
+      { statement: "IfStatement", headerLine: 1, bodyEndLine: 1, depth: 0 },
+    ]);
+  });
+
+  it("covers every compound statement name in grammarInfo", () => {
+    const samples = [
+      "if a:\n    pass\n",
+      "while True:\n    pass\n",
+      "for x in y:\n    pass\n",
+      "try:\n    pass\nexcept:\n    pass\n",
+      "with a:\n    pass\n",
+      "def foo():\n    pass\n",
+      "class Foo:\n    pass\n",
+    ];
+    const seen = new Set(
+      samples.flatMap((doc) => blockRuns(doc).map((r) => r.statement))
+    );
+    expect([...grammarInfo.compoundStatements].sort()).toEqual(
+      [...seen].sort()
+    );
+  });
+});

--- a/src/editor/codemirror/structure-highlighting/view.ts
+++ b/src/editor/codemirror/structure-highlighting/view.ts
@@ -119,7 +119,7 @@ export const codeStructureView = (option: "full" | "simple") =>
             end - 1,
             topLineNumber
           );
-          if (!bottomPos) {
+          if (bottomPos === undefined) {
             // Not sure if this is possible in practice due to the grammar,
             // but best to bail if we encounter it in error scenarios.
             return undefined;

--- a/src/editor/codemirror/structure-highlighting/view.ts
+++ b/src/editor/codemirror/structure-highlighting/view.ts
@@ -6,24 +6,12 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { indentUnit, syntaxTree } from "@codemirror/language";
+import { indentUnit } from "@codemirror/language";
 import { EditorView, ViewPlugin, ViewUpdate } from "@codemirror/view";
 import { lintState } from "../lint/lint";
+import { codeBlocks } from "./blocks";
 import { overlapsUnnecessaryCode, skipBodyTrailers } from "./doc-util";
 import { Positions, VisualBlock } from "./visual-block";
-
-// Grammar is defined by https://github.com/lezer-parser/python/blob/master/src/python.grammar
-const grammarInfo = {
-  compoundStatements: new Set([
-    "IfStatement",
-    "WhileStatement",
-    "ForStatement",
-    "TryStatement",
-    "WithStatement",
-    "FunctionDefinition",
-    "ClassDefinition",
-  ]),
-};
 
 class Measure {
   constructor(
@@ -155,81 +143,33 @@ export const codeStructureView = (option: "full" | "simple") =>
 
         const bodyPullBack = option === "full";
         const blocks: VisualBlock[] = [];
-        // We could throw away blocks if we tracked returning to the top-level or started from
-        // the closest top-level node. Otherwise we need to render them because they overlap.
-        // Should consider switching to tree cursors to avoid allocating syntax nodes.
-        let depth = 0;
-        const tree = syntaxTree(state);
-        const parents: {
-          name: string;
-          children?: { name: string; start: number; end: number }[];
-        }[] = [];
-        if (tree) {
-          tree.iterate({
-            enter: (node) => {
-              parents.push({ name: node.type.name });
-              if (node.type.name === "Body") {
-                depth++;
-              }
-            },
-            leave: (node) => {
-              if (node.type.name === "Body") {
-                depth--;
-              }
-
-              const leaving = parents.pop()!;
-              const children = leaving.children;
-              if (children) {
-                // Draw an l-shape for each run of non-Body (e.g. keywords, test expressions) followed by Body in the child list.
-                let runStart = 0;
-                for (let i = 0; i < children.length; ++i) {
-                  if (children[i].name === "Body") {
-                    const startNode = children[runStart];
-                    const bodyNode = children[i];
-
-                    const parentPositions = positionsForNode(
-                      view,
-                      startNode.start,
-                      bodyNode.start,
-                      depth,
-                      undefined
-                    );
-                    const bodyPositions = positionsForNode(
-                      view,
-                      bodyNode.start,
-                      bodyNode.end,
-                      depth + 1,
-                      parentPositions
-                    );
-                    if (parentPositions && bodyPositions) {
-                      blocks.push(
-                        new VisualBlock(
-                          bodyPullBack,
-                          width,
-                          parentPositions,
-                          bodyPositions
-                        )
-                      );
-                    }
-                    runStart = i + 1;
-                  }
-                }
-              }
-
-              // Poke our information into our parent if we need to track it.
-              const parent = parents[parents.length - 1];
-              if (parent && grammarInfo.compoundStatements.has(parent.name)) {
-                if (!parent.children) {
-                  parent.children = [];
-                }
-                parent.children.push({
-                  name: node.type.name,
-                  start: node.from,
-                  end: node.to,
-                });
-              }
-            },
-          });
+        // Innermost first, as positionsForNode's cursor attribution relies on.
+        for (const block of codeBlocks(state)) {
+          // Draw an l-shape for each header/body run.
+          const parentPositions = positionsForNode(
+            view,
+            block.start,
+            block.bodyStart,
+            block.depth,
+            undefined
+          );
+          const bodyPositions = positionsForNode(
+            view,
+            block.bodyStart,
+            block.bodyEnd,
+            block.depth + 1,
+            parentPositions
+          );
+          if (parentPositions && bodyPositions) {
+            blocks.push(
+              new VisualBlock(
+                bodyPullBack,
+                width,
+                parentPositions,
+                bodyPositions
+              )
+            );
+          }
         }
         return new Measure(width, gutterWidth, blocks.reverse());
       }


### PR DESCRIPTION
Motivated by de-risking upgrades.

There's one non-trivial change to the code structure highlighting to better share between the test/implementation. Seems OK from manual testing.