### PR TITLE
Move to ESLint 10 and @microbit/eslint-config 0.2.1

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,7 +33,6 @@ export default [
       "@typescript-eslint/no-unsafe-member-access": "off",
       "@typescript-eslint/no-unsafe-return": "off",
       "@typescript-eslint/require-await": "off",
-      "react/display-name": "off",
       // Debt to be reviewed: React-compiler-era hooks rules with existing
       // violations too involved to fix as part of lint config unification.
       "react-hooks/immutability": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
       "devDependencies": {
         "@csstools/postcss-cascade-layers": "^6.0.0",
         "@formatjs/cli": "^6.2.7",
-        "@microbit/eslint-config": "^0.1.0",
+        "@microbit/eslint-config": "^0.2.1",
         "@pandacss/dev": "^1.11.4",
         "@playwright/test": "^1.58.2",
         "@testing-library/jest-dom": "^5.14.1",
@@ -64,7 +64,7 @@
         "@vitejs/plugin-react": "^5.1.4",
         "cross-env": "^7.0.3",
         "ejs": "^3.1.9",
-        "eslint": "^9.39.5",
+        "eslint": "^10.9.1",
         "jsdom": "^28.1.0",
         "playwright": "^1.58.2",
         "prettier": "2.3.2",
@@ -2523,19 +2523,6 @@
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
-    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
@@ -2546,106 +2533,239 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
+    "node_modules/@eslint-react/ast": {
+      "version": "5.18.6",
+      "resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-5.18.6.tgz",
+      "integrity": "sha512-okgOez6L9onvcdU0lyLOykKQSaj2hMtVV2ucx2iqmTsfKDGyhVlMuNLnfyOkgQyHdgfROTVtAAYnQ6KPf7PggQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "^8.67.0",
+        "@typescript-eslint/typescript-estree": "^8.67.0",
+        "@typescript-eslint/utils": "^8.67.0",
+        "string-ts": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@eslint-react/core": {
+      "version": "5.18.6",
+      "resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-5.18.6.tgz",
+      "integrity": "sha512-utvjmfgy/lMSMt4QSU5QK2coHk6tkRChxLmkW6z8sthgmB6138CYzC3cPR9kze5pOgYJouF95xiaPnHKnXx21A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "5.18.6",
+        "@eslint-react/eslint": "5.18.6",
+        "@eslint-react/shared": "5.18.6",
+        "@eslint-react/var": "5.18.6",
+        "@typescript-eslint/scope-manager": "^8.67.0",
+        "@typescript-eslint/types": "^8.67.0",
+        "@typescript-eslint/utils": "^8.67.0",
+        "ts-pattern": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@eslint-react/eslint": {
+      "version": "5.18.6",
+      "resolved": "https://registry.npmjs.org/@eslint-react/eslint/-/eslint-5.18.6.tgz",
+      "integrity": "sha512-8BzLB6mtIDmAIwAt1u4g6Yp+1LSGAnqm8SGNHbyZG1sQikWW9Fskv3fx5Zy6CGMV9D7gafcHTiVTcuBYNE+87w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.67.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@eslint-react/eslint-plugin": {
+      "version": "5.18.6",
+      "resolved": "https://registry.npmjs.org/@eslint-react/eslint-plugin/-/eslint-plugin-5.18.6.tgz",
+      "integrity": "sha512-qBZXKx05CPNrvdNydM958rZt2hgVhhriU/8LUeS5s/5gdpuekflrfF+y3yT4NT8Ej3J37h7e50RdH6Lu1r0KPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/shared": "5.18.6",
+        "eslint-plugin-react-dom": "5.18.6",
+        "eslint-plugin-react-jsx": "5.18.6",
+        "eslint-plugin-react-naming-convention": "5.18.6",
+        "eslint-plugin-react-rsc": "5.18.6",
+        "eslint-plugin-react-web-api": "5.18.6",
+        "eslint-plugin-react-x": "5.18.6"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@eslint-react/jsx": {
+      "version": "5.18.6",
+      "resolved": "https://registry.npmjs.org/@eslint-react/jsx/-/jsx-5.18.6.tgz",
+      "integrity": "sha512-oAbG2pW6XhiROZotfSjLU19A84/AxYHiiKjim5USHH5xtYfYjO7skFSM6LztuPggqn/wccSxLgmKIFGUKM/95g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "5.18.6",
+        "@eslint-react/eslint": "5.18.6",
+        "@eslint-react/shared": "5.18.6",
+        "@eslint-react/var": "5.18.6",
+        "@typescript-eslint/types": "^8.67.0",
+        "@typescript-eslint/utils": "^8.67.0",
+        "ts-pattern": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@eslint-react/shared": {
+      "version": "5.18.6",
+      "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-5.18.6.tgz",
+      "integrity": "sha512-zCzb/W1xwG412BWVTjqhDznsJEHdyZVkVJz4jbAebHLpKxygK5XeG+vShdYbIFC7OcJU8hYbvEf3P2UNqXVhBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/eslint": "5.18.6",
+        "@typescript-eslint/utils": "^8.67.0",
+        "ts-pattern": "^5.9.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@eslint-react/var": {
+      "version": "5.18.6",
+      "resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-5.18.6.tgz",
+      "integrity": "sha512-5pxFlOy0Ajx+JUz4I4PwnYtOrqcj/R59Gx9m/WWjukFza/ap3FYnu8vEl2Q0txUQoUPJ7euPnBhkKOE7LhsOWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "5.18.6",
+        "@eslint-react/eslint": "5.18.6",
+        "@typescript-eslint/scope-manager": "^8.67.0",
+        "@typescript-eslint/types": "^8.67.0",
+        "@typescript-eslint/utils": "^8.67.0",
+        "ts-pattern": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "typescript": "*"
+      }
+    },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
-      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.3.0",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.5",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
-      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@exodus/bytes": {
@@ -3263,23 +3383,23 @@
       }
     },
     "node_modules/@microbit/eslint-config": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@microbit/eslint-config/-/eslint-config-0.1.2.tgz",
-      "integrity": "sha512-vlxWcypkr0pjbSyuUQ2jLa6LQWhexoP3yOKjCRRWal7Mh88c4hnm/G8YJU+9TakKfPSE4nKmLdK53+tjEtff3g==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@microbit/eslint-config/-/eslint-config-0.2.1.tgz",
+      "integrity": "sha512-AV4SN0er+orgX8CwMksrC6KI1wnUBqubz7F1qKK0iUyHoJTt/9+HLR14H8ohcOf+9W+cZf2P4Dbtx5FIpW0POg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint/js": "^9.0.0",
+        "@eslint-react/eslint-plugin": "^5.18.6",
+        "@eslint/js": "^10.0.0",
         "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "typescript-eslint": "^8.68.0"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "eslint": "^9.7.0"
+        "eslint": "^10.0.0"
       }
     },
     "node_modules/@microbit/microbit-connection": {
@@ -4808,42 +4928,6 @@
         "tinyglobby": "^0.2.14"
       }
     },
-    "node_modules/@ts-morph/common/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@ts-morph/common/node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.8"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -4918,6 +5002,13 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.5.tgz",
       "integrity": "sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5306,45 +5397,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.8"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
@@ -5744,105 +5796,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array-includes": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
-      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.24.0",
-        "es-object-atoms": "^1.1.1",
-        "get-intrinsic": "^1.3.0",
-        "is-string": "^1.1.1",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.findlast": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
-      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.flat": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
-      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.flatmap": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
-      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.tosorted": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
-      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.3",
-        "es-errors": "^1.3.0",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
@@ -6018,15 +5971,32 @@
         "require-from-string": "^2.0.2"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+    "node_modules/birecord": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/birecord/-/birecord-0.1.2.tgz",
+      "integrity": "sha512-5PAPTTmMpMEb+GuMb5DebfBkipRGyIW9+gtwEBSoDA9xkhHILm04+hZQ702pMksu3d8YAuGkmgTzQWcKqTPScA==",
       "dev": true,
+      "license": "(MIT OR Apache-2.0)"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -6308,10 +6278,10 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6737,19 +6707,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -6971,34 +6928,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es-iterator-helpers": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.4.0.tgz",
-      "integrity": "sha512-c/A0P0oxkACDc+cKWw8evLXK83oBKgn0qPOqCYT4x9uolpCIJAcYvJC9QYKNDRPsTeGyCrQ326jrvgZWdCdK5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.9",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.24.2",
-        "es-errors": "^1.3.0",
-        "es-set-tostringtag": "^2.1.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.3.0",
-        "globalthis": "^1.0.4",
-        "gopd": "^1.2.0",
-        "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "internal-slot": "^1.1.0",
-        "iterator.prototype": "^1.1.5",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
@@ -7029,19 +6958,6 @@
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-shim-unscopables": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
-      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
         "hasown": "^2.0.2"
       },
       "engines": {
@@ -7133,34 +7049,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.5",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
-      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
-      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
+      "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.6",
-        "@eslint/js": "9.39.5",
-        "@eslint/plugin-kit": "^0.4.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.7.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -7170,8 +7085,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -7179,7 +7093,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -7209,37 +7123,27 @@
         "eslint": ">=7.0.0"
       }
     },
-    "node_modules/eslint-plugin-react": {
-      "version": "7.37.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
-      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+    "node_modules/eslint-plugin-react-dom": {
+      "version": "5.18.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-5.18.6.tgz",
+      "integrity": "sha512-xco47I0Agu+83QH2ONbgZd1JPLSXJON+gtFGJbOhgfPvetfO7UkcHu8iLpncopwyWekAXfhvomJsDlNLTm26/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "array-includes": "^3.1.8",
-        "array.prototype.findlast": "^1.2.5",
-        "array.prototype.flatmap": "^1.3.3",
-        "array.prototype.tosorted": "^1.1.4",
-        "doctrine": "^2.1.0",
-        "es-iterator-helpers": "^1.2.1",
-        "estraverse": "^5.3.0",
-        "hasown": "^2.0.2",
-        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "minimatch": "^3.1.2",
-        "object.entries": "^1.1.9",
-        "object.fromentries": "^2.0.8",
-        "object.values": "^1.2.1",
-        "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.5",
-        "semver": "^6.3.1",
-        "string.prototype.matchall": "^4.0.12",
-        "string.prototype.repeat": "^1.0.0"
+        "@eslint-react/ast": "5.18.6",
+        "@eslint-react/eslint": "5.18.6",
+        "@eslint-react/jsx": "5.18.6",
+        "@eslint-react/shared": "5.18.6",
+        "@typescript-eslint/types": "^8.67.0",
+        "@typescript-eslint/utils": "^8.67.0",
+        "compare-versions": "^6.1.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+        "eslint": "*",
+        "typescript": "*"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
@@ -7262,66 +7166,203 @@
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
+    "node_modules/eslint-plugin-react-jsx": {
+      "version": "5.18.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-jsx/-/eslint-plugin-react-jsx-5.18.6.tgz",
+      "integrity": "sha512-6EvzS5gZGfQ0byvSxgqV/F0qXTVnNGcCU7wgFZqz8I1IXmcbYyBCyU7gqNlKW1/1ptiZFmuwo57+eW6HyK+wEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "5.18.6",
+        "@eslint-react/core": "5.18.6",
+        "@eslint-react/eslint": "5.18.6",
+        "@eslint-react/jsx": "5.18.6",
+        "@eslint-react/shared": "5.18.6",
+        "@typescript-eslint/types": "^8.67.0",
+        "@typescript-eslint/utils": "^8.67.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "typescript": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react-naming-convention": {
+      "version": "5.18.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-naming-convention/-/eslint-plugin-react-naming-convention-5.18.6.tgz",
+      "integrity": "sha512-3KZkJN8XDTq6YtaYvyWJt3GQRjW3WhoVuGgLfhf0yO+8H0GW78FkesqGe//+np+pBXwPv6hck4c8ViTEQJ9qIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "5.18.6",
+        "@eslint-react/core": "5.18.6",
+        "@eslint-react/eslint": "5.18.6",
+        "@eslint-react/shared": "5.18.6",
+        "@eslint-react/var": "5.18.6",
+        "@typescript-eslint/types": "^8.67.0",
+        "@typescript-eslint/utils": "^8.67.0",
+        "ts-pattern": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "typescript": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react-rsc": {
+      "version": "5.18.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-rsc/-/eslint-plugin-react-rsc-5.18.6.tgz",
+      "integrity": "sha512-4mzLkRKRpN9Rr5JMeNrxkMFLHce1ikAdsjAiPOSIgYwWSsQWxHwpMTf+UfjXgfB6CcAcyKCyIe5HmOMX2kUoVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "5.18.6",
+        "@eslint-react/core": "5.18.6",
+        "@eslint-react/eslint": "5.18.6",
+        "@eslint-react/shared": "5.18.6",
+        "@eslint-react/var": "5.18.6",
+        "@typescript-eslint/types": "^8.67.0",
+        "@typescript-eslint/utils": "^8.67.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "typescript": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react-web-api": {
+      "version": "5.18.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-web-api/-/eslint-plugin-react-web-api-5.18.6.tgz",
+      "integrity": "sha512-r8s39AbHZ0071XcgCMoCdNkSARftqI6U/0bBJXPioVUw+hjp0n4EB27fsc69AHzRl/NJWA1oUJb+kcqxoWMR4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "5.18.6",
+        "@eslint-react/core": "5.18.6",
+        "@eslint-react/eslint": "5.18.6",
+        "@eslint-react/shared": "5.18.6",
+        "@eslint-react/var": "5.18.6",
+        "@typescript-eslint/types": "^8.67.0",
+        "@typescript-eslint/utils": "^8.67.0",
+        "birecord": "^0.1.2",
+        "ts-pattern": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "typescript": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react-x": {
+      "version": "5.18.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-5.18.6.tgz",
+      "integrity": "sha512-VvxeREksTiY9Q7YnpNvQNrjapUGu43rQJXrtbjT9ADwXX5nZiyUqD7T7fkbUYfH6NPz2bYvnAmGEctIfEGTTfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "5.18.6",
+        "@eslint-react/core": "5.18.6",
+        "@eslint-react/eslint": "5.18.6",
+        "@eslint-react/jsx": "5.18.6",
+        "@eslint-react/shared": "5.18.6",
+        "@eslint-react/var": "5.18.6",
+        "@typescript-eslint/scope-manager": "^8.67.0",
+        "@typescript-eslint/type-utils": "^8.67.0",
+        "@typescript-eslint/types": "^8.67.0",
+        "@typescript-eslint/typescript-estree": "^8.67.0",
+        "@typescript-eslint/utils": "^8.67.0",
+        "compare-versions": "^6.1.1",
+        "string-ts": "^2.3.1",
+        "ts-api-utils": "^2.5.0",
+        "ts-pattern": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "typescript": "*"
+      }
+    },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=10"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -7878,58 +7919,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.8"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globalthis": {
@@ -8752,24 +8741,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/iterator.prototype": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
-      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.6",
-        "get-proto": "^1.0.0",
-        "has-symbols": "^1.1.0",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/jackspeak": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
@@ -9206,22 +9177,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jsx-ast-utils": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
-      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-includes": "^3.1.6",
-        "array.prototype.flat": "^1.3.1",
-        "object.assign": "^4.1.4",
-        "object.values": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/keyv": {
@@ -9735,16 +9690,18 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minipass": {
@@ -9804,25 +9761,6 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/node-exports-info": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
-      "integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array.prototype.flatmap": "^1.3.3",
-        "es-errors": "^1.3.0",
-        "object.entries": "^1.1.9",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/node-releases": {
@@ -9914,60 +9852,6 @@
         "es-object-atoms": "^1.0.0",
         "has-symbols": "^1.1.0",
         "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.entries": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
-      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.fromentries": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
-      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.values": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
-      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10863,30 +10747,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve": {
-      "version": "2.0.0-next.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
-      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.2",
-        "node-exports-info": "^1.6.0",
-        "object-keys": "^1.1.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -11394,6 +11254,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-ts": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/string-ts/-/string-ts-2.3.1.tgz",
+      "integrity": "sha512-xSJq+BS52SaFFAVxuStmx6n5aYZU571uYUnUrPXkPFCfdHyZMMlbP2v2Wx5sNBnAVzq/2+0+mcBLBa3Xa5ubYw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -11434,17 +11301,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.repeat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
-      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
       }
     },
     "node_modules/string.prototype.trim": {
@@ -11555,19 +11411,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/style-mod": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "devDependencies": {
     "@csstools/postcss-cascade-layers": "^6.0.0",
     "@formatjs/cli": "^6.2.7",
+    "@microbit/eslint-config": "^0.2.1",
     "@pandacss/dev": "^1.11.4",
     "@playwright/test": "^1.58.2",
     "@testing-library/jest-dom": "^5.14.1",
@@ -67,15 +68,14 @@
     "@vitejs/plugin-react": "^5.1.4",
     "cross-env": "^7.0.3",
     "ejs": "^3.1.9",
+    "eslint": "^10.9.1",
     "jsdom": "^28.1.0",
     "playwright": "^1.58.2",
     "prettier": "2.3.2",
     "typescript": "^5.9.3",
     "vite-plugin-pwa": "^1.0.0",
     "vite-plugin-svgr": "^4.5.0",
-    "vitest": "^4.0.18",
-    "eslint": "^9.39.5",
-    "@microbit/eslint-config": "^0.1.0"
+    "vitest": "^4.0.18"
   },
   "engines": {
     "node": ">=24.0.0",

--- a/src/common/GenericDialog.tsx
+++ b/src/common/GenericDialog.tsx
@@ -44,11 +44,11 @@ export const GenericDialog = ({
       contentCss={{ minWidth: "560px" }}
     >
       <ModalCloseButton />
-      {header && (
+      {header ? (
         <ModalHeader level={2} css={{ fontWeight: "bold" }}>
           {header}
         </ModalHeader>
-      )}
+      ) : null}
       <ModalBody>{body}</ModalBody>
       <ModalFooter>{footer}</ModalFooter>
     </Modal>

--- a/src/common/HeadedScrollablePanel.tsx
+++ b/src/common/HeadedScrollablePanel.tsx
@@ -47,7 +47,7 @@ const HeadedScrollablePanel = ({
       gap="0"
       role="document"
     >
-      {heading && (
+      {heading ? (
         <Box
           bg="gray.75"
           flex="0 0 auto"
@@ -59,7 +59,7 @@ const HeadedScrollablePanel = ({
           <styled.header>{heading}</styled.header>
           <Divider thickness="thick" />
         </Box>
-      )}
+      ) : null}
       {children}
     </VStack>
   </ScrollablePanel>

--- a/src/common/InputDialog.tsx
+++ b/src/common/InputDialog.tsx
@@ -59,7 +59,7 @@ export const InputDialog = <T,>({
 }: InputDialogProps<T>) => {
   const [value, setValue] = useState(initialValue);
   const [validationResult, setValidationResult] =
-    useState<InputValidationResult>(validate(initialValue));
+    useState<InputValidationResult>(() => validate(initialValue));
   const onCancel = useCallback(() => callback(undefined), [callback]);
   const submit = useCallback(() => {
     if (validationResult.ok) {

--- a/src/common/SplitView/SplitViewSized.tsx
+++ b/src/common/SplitView/SplitViewSized.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { createRef, useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { Box } from "styled-system/jsx";
 import { dimensionPropName, useSplitViewContext } from "./context";
 
@@ -19,7 +19,7 @@ interface SizedPaneProps {
 const SplitViewSized = ({ children }: SizedPaneProps) => {
   const { direction, sizedPaneSize, compactSize, mode, dragging } =
     useSplitViewContext();
-  const ref = createRef<HTMLDivElement>();
+  const ref = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (ref.current) {
       const size = (() => {

--- a/src/deployment/index.ts
+++ b/src/deployment/index.ts
@@ -51,6 +51,7 @@ export interface DeploymentConfig {
   logging: Logging;
 }
 
+// eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix -- hook-shaped by design and used as one throughout
 export const useDeployment = (): DeploymentConfig => {
   return deployment;
 };

--- a/src/device/device-hooks.tsx
+++ b/src/device/device-hooks.tsx
@@ -237,6 +237,7 @@ export const DeviceContextProvider = ({
   value: MicrobitUSBConnection;
   children: ReactNode;
 }) => {
+  // eslint-disable-next-line @eslint-react/use-state -- the tuple is handed to context as-is
   const syncStatusState = useState<SyncStatus>(SyncStatus.OUT_OF_SYNC);
   const [, setSyncStatus] = syncStatusState;
   const fs = useFileSystem();

--- a/src/documentation/common/DocString.tsx
+++ b/src/documentation/common/DocString.tsx
@@ -29,6 +29,7 @@ const DocString = React.memo(
     return (
       <Component
         className={cx("docs-spacing docs-code", underlineLinksClass)}
+        // eslint-disable-next-line @eslint-react/dom-no-dangerously-set-innerhtml -- documentation HTML from our own content pipeline
         dangerouslySetInnerHTML={html}
         css={cssProp}
       />

--- a/src/documentation/common/DocumentationBreadcrumbHeading.tsx
+++ b/src/documentation/common/DocumentationBreadcrumbHeading.tsx
@@ -130,7 +130,7 @@ const DocumentationBreadcrumbHeading = ({
             >
               {title} {isV2Only && <V2Tag ml="2.5" />}
             </Text>
-            {subtitle && (
+            {subtitle ? (
               <Collapse
                 isOpen={!reduced}
                 unmountOnExit={true}
@@ -140,7 +140,7 @@ const DocumentationBreadcrumbHeading = ({
                   {subtitle}
                 </Text>
               </Collapse>
-            )}
+            ) : null}
           </VStack>
         </HStack>
       </Stack>

--- a/src/documentation/reference/Highlight.tsx
+++ b/src/documentation/reference/Highlight.tsx
@@ -47,6 +47,7 @@ const Highlight = ({
       logging.log("Activating " + id);
       disclosure.onOpen();
       // Delay until after the opening animation so the full container height is known for the scroll.
+      // eslint-disable-next-line @eslint-react/web-api-no-leaked-timeout -- one-shot scroll and highlight sequence
       window.setTimeout(() => {
         if (ref.current && scrollable.current) {
           const stickyHeaderHeight = scrollable.current
@@ -58,8 +59,10 @@ const Highlight = ({
             behavior: prefersReducedMotion ? "auto" : "smooth",
           });
         }
+        // eslint-disable-next-line @eslint-react/web-api-no-leaked-timeout -- one-shot scroll and highlight sequence
         setTimeout(() => {
           setHighlighting(true);
+          // eslint-disable-next-line @eslint-react/web-api-no-leaked-timeout -- one-shot scroll and highlight sequence
           setTimeout(() => {
             setHighlighting(false);
           }, 3000);

--- a/src/documentation/search/SearchResultList.tsx
+++ b/src/documentation/search/SearchResultList.tsx
@@ -106,10 +106,12 @@ const ExtractText = ({ extract, title, ...props }: ExtractTextProps) => {
     <Text {...props}>
       {extract.map((t, i) =>
         t.type === "text" ? (
+          // eslint-disable-next-line @eslint-react/no-array-index-key -- position is the only identity here
           <Text key={i} as="span">
             {t.extract}
           </Text>
         ) : (
+          // eslint-disable-next-line @eslint-react/no-array-index-key -- position is the only identity here
           <Text key={i} as="span" bgColor="#6C4BC14D" borderRadius="md" p="0.5">
             {t.extract}
           </Text>

--- a/src/editor/active-editor-hooks.tsx
+++ b/src/editor/active-editor-hooks.tsx
@@ -102,6 +102,7 @@ const ActiveEditorStateContext = React.createContext<
 >(undefined);
 
 const ActiveEditorStateProvider = ({ children }: { children: ReactNode }) => {
+  // eslint-disable-next-line @eslint-react/use-state -- the tuple is handed to context as-is
   const value = useState<EditorInfo>(defaultEditorInfo);
   return (
     <ActiveEditorStateContext.Provider value={value}>
@@ -116,6 +117,7 @@ interface ActiveEditorProviderProps {
 export const ActiveEditorProvider = ({
   children,
 }: ActiveEditorProviderProps) => {
+  // eslint-disable-next-line @eslint-react/use-state -- the tuple is handed to context as-is
   const actions = useState<EditorActions>();
   return (
     <ActiveEditorActionsContext.Provider value={actions}>

--- a/src/editor/codemirror/language-server/common.ts
+++ b/src/editor/codemirror/language-server/common.ts
@@ -7,16 +7,16 @@ import { Facet } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { LanguageServerClient } from "../../../language-server/client";
 
-const useLast = <T>(values: readonly T[]) => values[values.length - 1] ?? null;
+const lastOf = <T>(values: readonly T[]) => values[values.length - 1] ?? null;
 // Used internally.
 export const uriFacet = Facet.define<string | null, string | null>({
-  combine: useLast,
+  combine: lastOf,
 });
 // Used internally.
 export const clientFacet = Facet.define<
   LanguageServerClient | null,
   LanguageServerClient | null
->({ combine: useLast });
+>({ combine: lastOf });
 
 export abstract class BaseLanguageServerView {
   constructor(protected view: EditorView) {}

--- a/src/project/project-hooks.tsx
+++ b/src/project/project-hooks.tsx
@@ -82,7 +82,7 @@ export const useProject = (): DefaultedProject => {
   const fs = useFileSystem();
   const intl = useIntl();
   const isUnmounted = useIsUnmounted();
-  const [state, setState] = useState<DefaultedProject>(
+  const [state, setState] = useState<DefaultedProject>(() =>
     defaultedProject(fs, intl)
   );
   useEffect(() => {

--- a/src/router-hooks.tsx
+++ b/src/router-hooks.tsx
@@ -96,7 +96,7 @@ export const toUrl = (state: RouterState): string => {
 
 export const RouterProvider = ({ children }: { children: ReactNode }) => {
   const logging = useLogging();
-  const [state, setState] = useState(parse(window.location.pathname));
+  const [state, setState] = useState(() => parse(window.location.pathname));
   useEffect(() => {
     // This detects browser navigation but not our programatic changes,
     // so we need to update state there ourselves.

--- a/src/serial/XTerm.tsx
+++ b/src/serial/XTerm.tsx
@@ -177,7 +177,9 @@ const useManagedTermimal = (
     };
     coreTerminal._initGlobal = () => {
       // We don't need to remove these as we share a lifetime with this DOM.
+      // eslint-disable-next-line @eslint-react/web-api-no-leaked-event-listener -- shares its lifetime with the terminal DOM, as the note above says
       terminal.element!.addEventListener("paste", customPasteEventHandler);
+      // eslint-disable-next-line @eslint-react/web-api-no-leaked-event-listener -- shares its lifetime with the terminal DOM, as the note above says
       terminal.textarea!.addEventListener("paste", customPasteEventHandler);
       initGlobal();
     };

--- a/src/simulator/DataLoggingModule.tsx
+++ b/src/simulator/DataLoggingModule.tsx
@@ -127,6 +127,7 @@ const DataLoggingModule = ({
                 </styled.tr>
               )}
               {truncatedDataLog.data.map((row, rowNum) => (
+                // eslint-disable-next-line @eslint-react/no-array-index-key -- position is the only identity here
                 <styled.tr key={rowNum}>
                   {row.data.map((cell, headingIndex) => {
                     return (

--- a/src/simulator/Simulator.tsx
+++ b/src/simulator/Simulator.tsx
@@ -131,6 +131,7 @@ const Simulator = ({
                 frameBorder="no"
                 scrolling="no"
                 allow="autoplay;microphone"
+                // eslint-disable-next-line @eslint-react/dom-no-unsafe-iframe-sandbox -- the simulator is served from a separate origin
                 sandbox="allow-scripts allow-same-origin"
               />
             </AspectRatio>

--- a/src/simulator/tab-control-hooks.tsx
+++ b/src/simulator/tab-control-hooks.tsx
@@ -23,6 +23,7 @@ export const useSimSerialTabControl = (): SimSerialTabControl => {
 };
 
 const SimSerialTabControlProvider = ({ children }: { children: ReactNode }) => {
+  // eslint-disable-next-line @eslint-react/use-state -- the tuple is handed to context as-is
   const value = useState<HTMLElement | null>(null);
   return (
     <SimSerialTabControlContext.Provider value={value}>

--- a/src/workbench/AboutDialog/AboutDialog.tsx
+++ b/src/workbench/AboutDialog/AboutDialog.tsx
@@ -92,7 +92,7 @@ const AboutDialog = ({ isOpen, onClose, finalFocusRef }: AboutDialogProps) => {
       <ModalBody>
         <VStack gap="8" pl="5" pr="5" pt="5">
           <HStack gap="4">
-            {deployment.horizontalLogo && (
+            {deployment.horizontalLogo ? (
               <Flex
                 alignItems="center"
                 justifyContent="flex-end"
@@ -101,7 +101,7 @@ const AboutDialog = ({ isOpen, onClose, finalFocusRef }: AboutDialogProps) => {
               >
                 {deployment.horizontalLogo}
               </Flex>
-            )}
+            ) : null}
             <Flex alignItems="center" justifyContent="flex-end">
               {/* No need to translate */}
               <Image src={micropythonLogo} alt="MicroPython" />
@@ -202,7 +202,11 @@ const AboutDialog = ({ isOpen, onClose, finalFocusRef }: AboutDialogProps) => {
                   ))}
                 </styled.tbody>
               </styled.table>
-              <Button startIcon={<RiFileCopy2Line />} onPress={onCopy} size="md">
+              <Button
+                startIcon={<RiFileCopy2Line />}
+                onPress={onCopy}
+                size="md"
+              >
                 <FormattedMessage id={hasCopied ? "copied" : "copy-action"} />
               </Button>
             </VStack>

--- a/src/workbench/use-selection.tsx
+++ b/src/workbench/use-selection.tsx
@@ -50,6 +50,7 @@ export const useSelection = () => {
 };
 
 export const SelectionProvider = ({ children }: { children: ReactNode }) => {
+  // eslint-disable-next-line @eslint-react/use-state -- the tuple is handed to context as-is
   const state = useState<WorkbenchSelection>({
     file: MAIN_FILE,
     location: { line: undefined },


### PR DESCRIPTION
Drop the react/display-name carve-out: the rule went with eslint-plugin-react. Worth knowing that a stale carve-out like this does not fail the run, because ESLint tolerates an "off" entry for a rule it cannot find. It just quietly stops doing anything.

eslint-react reports 25 things the old plugin did not. Eight are worth fixing.

Four are leaked conditional renders, all guarding a ReactNode with &&, so a caller passing 0 renders a literal "0". Ternaries with null.

SplitViewSized called createRef in a function component, which builds a fresh ref object on every render. That object is in the effect's dependency array, so the effect re-ran every render. useRef is stable.

Three components seeded state with a function call on every render: InputDialog, project-hooks and router-hooks. Lazy initialisers.

useLast in the language server common module is a Facet combiner, not a hook, and is only used in that file. Now lastOf.

The rest are deliberate and now say so: five hooks hand a useState tuple straight to context, the simulator iframe is same-origin-sandboxed because it is served from a separate origin, XTerm's paste listeners share their lifetime with the terminal DOM as its note explains, Highlight's timeouts are a one-shot scroll and highlight sequence, DocString renders documentation HTML from our own pipeline, search extracts and data log rows are positional, and useDeployment is hook-shaped by design.

npm cannot resolve this bump in one step. The lockfile pins the old shared config with its eslint ^9.7 peer and npm tries to reconcile that rather than replace it, failing with a circular ERESOLVE. Uninstall eslint and @microbit/eslint-config first, then install the new pair.