### PR TITLE
Exempt @codemirror/* from min-release-age; upgrade

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,7 @@
 min-release-age=7
 min-release-age-exclude[]=@microbit/*
 min-release-age-exclude[]=@microbit-foundation/*
+min-release-age-exclude[]=@codemirror/*
 
 # root here means this project's package.json
 allow-git=root

--- a/package-lock.json
+++ b/package-lock.json
@@ -1906,18 +1906,18 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
-      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.2.tgz",
+      "integrity": "sha512-U3RiPX62Wl/Gx4ftQ7UxLlloSfsFTQqKa+7vFBYteZGCzkp6oBqcsD7iSwniWRGobCAmDcwZSY+Six3+3ztdfg==",
       "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.43.9",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.9.tgz",
-      "integrity": "sha512-sTuUzTpPMFebRhg6dawChoKKgndIwfjmJgKVxBefPElcU2NwQ6AFroupk0SFqEerQyZOGRfDNnSN8Dw/lMAsXw==",
+      "version": "6.43.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.11.tgz",
+      "integrity": "sha512-2+esucbQX6wB2JYi1eDvdCPFTA31BN8oSy6xCmk3G6CloV11yOvEjYk+gH7kLrP0MuHG94E8WDhjs5oMiu3+Wg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.7.0",


### PR DESCRIPTION
I'll open a PR to revert the exception that we'll merge after > 7d so we don't accidentally regress this via lock file maintenance.

Fixes #1297